### PR TITLE
Add CR for openebs 2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sleep 15
   - sudo apt-get install -y
   - sudo apt-get install -y curl
-  - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+  - curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
   - chmod 700 get_helm.sh
   - sudo ./get_helm.sh
 script:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 REPONAME = openebs
 IMGNAME = helm-operator
-IMGTAG = v0.0.6
-OPENEBS_RELEASE_VERSION = 2.10.0
+IMGTAG = v0.0.7
+OPENEBS_RELEASE_VERSION = 2.11.0
 IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ build:
 	@echo "Fetch openebs helm chart from stable"
 	@echo "------------------------------------"
      
-	helm init --client-only
 	helm repo add openebs https://openebs.github.io/charts
 	helm fetch openebs/openebs --version $(OPENEBS_RELEASE_VERSION) --untar --untardir helm-charts/
 	ls helm-charts/

--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Example of OpenEBSInstallTemplate CR can be found [here](deploy/crds/openebs_v1a
      | v0.0.4               | 1.4.0                 |
      | v0.0.5               | 1.5.0                 |
      | v0.0.6               | 2.10.0                |
+     | v0.0.7               | 2.11.0                |

--- a/deploy/crds/openebs_v1alpha1_openebsinstalltemplate_cr.yaml
+++ b/deploy/crds/openebs_v1alpha1_openebsinstalltemplate_cr.yaml
@@ -1,146 +1,153 @@
 apiVersion: openebs.io/v1alpha1
 kind: OpenEBSInstallTemplate
 metadata:
-  name: oebs 
+  name: oebs
   namespace: openebs
 spec:
   # Default values copied from <project_dir>/helm-charts/openebs/values.yaml
-  
   # Default values for openebs.
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
-  
   rbac:
-    # Specifies whether RBAC resources should be created
+  # Specifies whether RBAC resources should be created
     create: true
-  
+    pspEnabled: false
+    kyvernoEnabled: false
   serviceAccount:
     create: true
-    name: "openebs-maya-operator"
-
+    name: ''
   release:
-    # "openebs.io/version" label for control plane components
-    version: "2.10.0"
-  
+  # "openebs.io/version" label for control plane components
+    version: 2.11.0
+  legacy:
+    enabled: true
   image:
     pullPolicy: IfNotPresent
-  
+    repository: ''
   apiserver:
-    image: "quay.io/openebs/m-apiserver"
-    imageTag: "2.10.0"
+    enabled: true
+    image: quay.io/openebs/m-apiserver
+    imageTag: 2.11.0
     replicas: 1
     ports:
       externalPort: 5656
       internalPort: 5656
     sparse:
-      enabled: "false"
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
+      enabled: 'false'
     healthCheck:
       initialDelaySeconds: 30
       periodSeconds: 60
-  
+  defaultStorageConfig:
+    enabled: 'true'
+  varDirectoryPath:
+    baseDir: "/var/openebs"
   provisioner:
-    image: "quay.io/openebs/openebs-k8s-provisioner"
-    imageTag: "2.10.0"
-    replicas: 1
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
-    healthCheck:
-      initialDelaySeconds: 30
-      periodSeconds: 60
-
-  localprovisioner:
-    image: "quay.io/openebs/provisioner-localpv"
-    imageTag: "2.10.0"
-    helperImage: "quay.io/openebs/linux-utils"
-    helperImageTag: "2.10.0"
-    replicas: 1
-    basePath: "/var/openebs/local"
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
-    healthCheck:
-      initialDelaySeconds: 30
-      periodSeconds: 60
-  
-  snapshotOperator:
-    controller:
-      image: "quay.io/openebs/snapshot-controller"
-      imageTag: "2.10.0"
-    provisioner:
-      image: "quay.io/openebs/snapshot-provisioner"
-      imageTag: "2.10.0"
+    enabled: true
+    image: quay.io/openebs/openebs-k8s-provisioner
+    imageTag: 2.11.0
     replicas: 1
     enableLeaderElection: true
-    upgradeStrategy: "Recreate"
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
+    patchJivaNodeAffinity: enabled
     healthCheck:
       initialDelaySeconds: 30
       periodSeconds: 60
-  
+  localprovisioner:
+    enabled: true
+    image: quay.io/openebs/provisioner-localpv
+    imageTag: 2.11.1
+    replicas: '1'
+    basePath: "/var/openebs/local"
+    enableLeaderElection: true
+    healthCheck:
+      initialDelaySeconds: '30'
+      periodSeconds: '60'
+  snapshotOperator:
+    enabled: true
+    controller:
+      image: quay.io/openebs/snapshot-controller
+      imageTag: 2.11.0
+    provisioner:
+      image: quay.io/openebs/snapshot-provisioner
+      imageTag: 2.11.0
+    replicas: 1
+    enableLeaderElection: true
+    upgradeStrategy: Recreate
+    healthCheck:
+      initialDelaySeconds: 30
+      periodSeconds: 60
   ndm:
-    image: "quay.io/openebs/node-disk-manager"
-    imageTag: "1.5.0"
+    enabled: true
+    image: quay.io/openebs/node-disk-manager
+    imageTag: 1.6.0
     sparse:
       path: "/var/openebs/sparse"
-      size: "10737418240"
-      count: "0"
+      size: '10737418240'
+      count: '0'
     filters:
       enableOsDiskExcludeFilter: true
       osDiskExcludePaths: "/,/etc/hosts,/boot"
-      enableVendorFilter: true
-      excludeVendors: "CLOUDBYT,OpenEBS"
-      includePaths: ""
+      enableVendorFilter: 'true'
+      excludeVendors: CLOUDBYT,OpenEBS
       enablePathFilter: true
+      includePaths: ''
       excludePaths: "/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd"
-    nodeSelector: {}
     probes:
       enableSeachest: false
     healthCheck:
       initialDelaySeconds: 30
       periodSeconds: 60
-
   ndmOperator:
-    image: "quay.io/openebs/node-disk-operator"
-    imageTag: "1.5.0"
+    image: quay.io/openebs/node-disk-operator
+    imageTag: 1.6.0
     replicas: 1
     upgradeStrategy: Recreate
-    nodeSelector: {}
-    tolerations: []
     healthCheck:
-      initialDelaySeconds: 30
-      periodSeconds: 60
+      initialDelaySeconds: 15
+      periodSeconds: 20
     readinessCheck:
-      initialDelaySeconds: 4
-      periodSeconds: 10
-      failureThreshold: 1
-    cleanupImage: "quay.io/openebs/linux-utils"
-    cleanupImageTag: "2.10.0"
-
-
+      initialDelaySeconds: 5
+      periodSeconds: 20
   webhook:
     enabled: true
-    image: "quay.io/openebs/admission-server"
-    imageTag: "2.10.0"
-    failurePolicy: "Fail"
-    generateTLS: true
+    image: quay.io/openebs/admission-server
+    imageTag: 2.11.0
+    failurePolicy: Fail
     replicas: 1
     healthCheck:
       initialDelaySeconds: 30
       periodSeconds: 60
-    nodeSelector: {}
-    tolerations: []
-    affinity: {}
     hostNetwork: false
-
+  helper:
+    image: quay.io/openebs/linux-utils
+    helperImageTag: 2.11.0
+  featureGates:
+    enabled: true
+    GPTBasedUUID:
+      enabled: true
+      featureGateFlag: GPTBasedUUID
+    APIService:
+      enabled: false
+      featureGateFlag: APIService
+      address: 0.0.0.0:9115
+    USeOSDisk:
+      enabled: false
+      featureGateFlag: UseOSDisk
+    MountChangeDetection:
+      enabled: false
+      featureGateFlag: MountChangeDetection
+  crd:
+    enableInstall: true
+  policies:
+    monitoring:
+      enabled: true
+      image: quay.io/openebs/m-exporter
+      imageTag: 2.11.0
+  analytics:
+    enabled: true
+    pingInterval: 24h
   jiva:
-    image: "quay.io/openebs/jiva"
-    imageTag: "2.10.0"
+    image: quay.io/openebs/jiva
+    imageTag: 2.11.0
     replicas: 3
     defaultStoragePath: "/var/openebs"
     enabled: false
@@ -149,30 +156,30 @@ spec:
     localpv-provisioner:
       openebsNDM:
         enabled: false
-
-  
   cstor:
     pool:
-      image: "quay.io/openebs/cstor-pool"
-      imageTag: "2.10.0"
+      image: quay.io/openebs/cstor-pool
+      imageTag: 2.11.0
     poolMgmt:
-      image: "quay.io/openebs/cstor-pool-mgmt"
-      imageTag: "2.10.0"
+      image: quay.io/openebs/cstor-pool-mgmt
+      imageTag: 2.11.0
     target:
-      image: "quay.io/openebs/cstor-istgt"
-      imageTag: "2.10.0"
+      image: quay.io/openebs/cstor-istgt
+      imageTag: 2.11.0
     volumeMgmt:
-      image: "quay.io/openebs/cstor-volume-mgmt"
-      imageTag: "2.10.0"
-  
-  policies:
-    monitoring:
-      enabled: true
-      image: "quay.io/openebs/m-exporter"
-      imageTag: "2.10.0"
-  
-  analytics:
-    enabled: true
-    # Specify in hours the duration after which a ping event needs to be sent.
-    pingInterval: "24h"
-  
+      image: quay.io/openebs/cstor-volume-mgmt
+      imageTag: 2.11.0
+    enabled: false
+    openebsNDM:
+      enabled: false
+  openebs-ndm:
+    enabled: false
+  localpv-provisioner:
+    enabled: false
+    openebsNDM:
+      enabled: false
+  zfs-localpv:
+    enabled: false
+  lvm-localpv:
+    enabled: false
+

--- a/olm/2.11.0/openebsoperator.v2.11.0.clusterserviceversion.yaml
+++ b/olm/2.11.0/openebsoperator.v2.11.0.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
                 "internalPort": 5656
               },
               "sparse": {
-                "enabled": "false"
+                "enabled": false
               },
               "healthCheck": {
                 "initialDelaySeconds": 30,
@@ -58,7 +58,7 @@ metadata:
               }
             },
             "defaultStorageConfig": {
-              "enabled": "true"
+              "enabled": true
             },
             "varDirectoryPath": {
               "baseDir": "/var/openebs"

--- a/olm/2.11.0/openebsoperator.v2.11.0.clusterserviceversion.yaml
+++ b/olm/2.11.0/openebsoperator.v2.11.0.clusterserviceversion.yaml
@@ -1,0 +1,575 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: openebsoperator.v2.11.0
+  namespace: default
+  annotations:
+    capabilities: Basic Install
+    categories: "Storage"
+    containerImage: index.docker.io/openebs/helm-operator:v0.0.7
+    createdAt: 2021-08-15T15:21:19Z
+    repository: https://github.com/openebs/helm-operator
+    certified: "false"
+    support: https://slack.openebs.io/
+    alm-examples: |
+      [
+        {
+          "apiVersion": "openebs.io/v1alpha1",
+          "kind": "OpenEBSInstallTemplate",
+          "metadata": {
+            "name": "oebs",
+            "namespace": "openebs"
+          },
+          "spec": {
+            "rbac": {
+              "create": true,
+              "pspEnabled": false,
+              "kyvernoEnabled": false
+            },
+            "serviceAccount": {
+              "create": true,
+              "name": ""
+            },
+            "release": {
+              "version": "2.11.0"
+            },
+            "legacy": {
+              "enabled": true
+            },
+            "image": {
+              "pullPolicy": "IfNotPresent",
+              "repository": ""
+            },
+            "apiserver": {
+              "enabled": true,
+              "image": "quay.io/openebs/m-apiserver",
+              "imageTag": "2.11.0",
+              "replicas": 1,
+              "ports": {
+                "externalPort": 5656,
+                "internalPort": 5656
+              },
+              "sparse": {
+                "enabled": "false"
+              },
+              "healthCheck": {
+                "initialDelaySeconds": 30,
+                "periodSeconds": 60
+              }
+            },
+            "defaultStorageConfig": {
+              "enabled": "true"
+            },
+            "varDirectoryPath": {
+              "baseDir": "/var/openebs"
+            },
+            "provisioner": {
+              "enabled": true,
+              "image": "quay.io/openebs/openebs-k8s-provisioner",
+              "imageTag": "2.11.0",
+              "replicas": 1,
+              "enableLeaderElection": true,
+              "patchJivaNodeAffinity": "enabled",
+              "healthCheck": {
+                "initialDelaySeconds": 30,
+                "periodSeconds": 60
+              }
+            },
+            "localprovisioner": {
+              "enabled": true,
+              "image": "quay.io/openebs/provisioner-localpv",
+              "imageTag": "2.11.1",
+              "replicas": "1",
+              "basePath": "/var/openebs/local",
+              "enableLeaderElection": true,
+              "healthCheck": {
+                "initialDelaySeconds": "30",
+                "periodSeconds": "60"
+              }
+            },
+            "snapshotOperator": {
+              "enabled": true,
+              "controller": {
+                "image": "quay.io/openebs/snapshot-controller",
+                "imageTag": "2.11.0"
+              },
+              "provisioner": {
+                "image": "quay.io/openebs/snapshot-provisioner",
+                "imageTag": "2.11.0"
+              },
+              "replicas": 1,
+              "enableLeaderElection": true,
+              "upgradeStrategy": "Recreate",
+              "healthCheck": {
+                "initialDelaySeconds": 30,
+                "periodSeconds": 60
+              }
+            },
+            "ndm": {
+              "enabled": true,
+              "image": "quay.io/openebs/node-disk-manager",
+              "imageTag": "1.6.0",
+              "sparse": {
+                "path": "/var/openebs/sparse",
+                "size": "10737418240",
+                "count": "0"
+              },
+              "filters": {
+                "enableOsDiskExcludeFilter": true,
+                "osDiskExcludePaths": "/,/etc/hosts,/boot",
+                "enableVendorFilter": "true",
+                "excludeVendors": "CLOUDBYT,OpenEBS",
+                "enablePathFilter": true,
+                "includePaths": "",
+                "excludePaths": "/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd"
+              },
+              "probes": {
+                "enableSeachest": false
+              },
+              "healthCheck": {
+                "initialDelaySeconds": 30,
+                "periodSeconds": 60
+              }
+            },
+            "ndmOperator": {
+              "image": "quay.io/openebs/node-disk-operator",
+              "imageTag": "1.6.0",
+              "replicas": 1,
+              "upgradeStrategy": "Recreate",
+              "healthCheck": {
+                "initialDelaySeconds": 15,
+                "periodSeconds": 20
+              },
+              "readinessCheck": {
+                "initialDelaySeconds": 5,
+                "periodSeconds": 20
+              }
+            },
+            "webhook": {
+              "enabled": true,
+              "image": "quay.io/openebs/admission-server",
+              "imageTag": "2.11.0",
+              "failurePolicy": "Fail",
+              "replicas": 1,
+              "healthCheck": {
+                "initialDelaySeconds": 30,
+                "periodSeconds": 60
+              },
+              "hostNetwork": false
+            },
+            "helper": {
+              "image": "quay.io/openebs/linux-utils",
+              "helperImageTag": "2.11.0"
+            },
+            "featureGates": {
+              "enabled": true,
+              "GPTBasedUUID": {
+                "enabled": true,
+                "featureGateFlag": "GPTBasedUUID"
+              },
+              "APIService": {
+                "enabled": false,
+                "featureGateFlag": "APIService",
+                "address": "0.0.0.0:9115"
+              },
+              "USeOSDisk": {
+                "enabled": false,
+                "featureGateFlag": "UseOSDisk"
+              },
+              "MountChangeDetection": {
+                "enabled": false,
+                "featureGateFlag": "MountChangeDetection"
+              }
+            },
+            "crd": {
+              "enableInstall": true
+            },
+            "policies": {
+              "monitoring": {
+                "enabled": true,
+                "image": "quay.io/openebs/m-exporter",
+                "imageTag": "2.11.0"
+              }
+            },
+            "analytics": {
+              "enabled": true,
+              "pingInterval": "24h"
+            },
+            "jiva": {
+              "image": "quay.io/openebs/jiva",
+              "imageTag": "2.11.0",
+              "replicas": 3,
+              "defaultStoragePath": "/var/openebs",
+              "enabled": false,
+              "openebsLocalpv": {
+                "enabled": false
+              },
+              "localpv-provisioner": {
+                "openebsNDM": {
+                  "enabled": false
+                }
+              }
+            },
+            "cstor": {
+              "pool": {
+                "image": "quay.io/openebs/cstor-pool",
+                "imageTag": "2.11.0"
+              },
+              "poolMgmt": {
+                "image": "quay.io/openebs/cstor-pool-mgmt",
+                "imageTag": "2.11.0"
+              },
+              "target": {
+                "image": "quay.io/openebs/cstor-istgt",
+                "imageTag": "2.11.0"
+              },
+              "volumeMgmt": {
+                "image": "quay.io/openebs/cstor-volume-mgmt",
+                "imageTag": "2.11.0"
+              },
+              "enabled": false,
+              "openebsNDM": {
+                "enabled": false
+              }
+            },
+            "openebs-ndm": {
+              "enabled": false
+            },
+            "localpv-provisioner": {
+              "enabled": false,
+              "openebsNDM": {
+                "enabled": false
+              }
+            },
+            "zfs-localpv": {
+              "enabled": false
+            },
+            "lvm-localpv": {
+              "enabled": false
+            },
+            "cleanup": {
+              "image": {
+                "registry": '',
+                "repository": "bitnami/kubectl",
+                "tag": ''
+              }
+            }
+          }
+        }
+      ]
+    description: Creates and maintains OpenEBS Control Plane deployments
+spec:
+  displayName: OpenEBS
+  description: >
+    **OpenEBS** is a leading container attached storage solution that enables the use
+    of containers for mission-critical, persistent workloads and for other stateful
+    workloads such as logging or Prometheus for example.
+
+    OpenEBS itself is deployed as just another container on your host and enables
+    storage services that can be designated on a per pod, application, cluster
+    or container level, including:
+
+    * Data persistence across nodes
+
+    * Synchronization of data across availability zones and cloud providers
+
+    * A common layer whether you are running on the cloud, or your bare metal
+
+    * Integration with Kubernetes, so developer and application intent flows into OpenEBS
+
+    * Management of tiering to and from S3 and other targets.
+
+    ## OpenEBS Operator
+
+    OpenEBS primarily provides container attached block storage (iSCSI volumes) by leveraging/aggregating the
+    storage on the nodes, with the storage controller itself running as a container. Different storage engines
+    (Jiva & cStor) are supported, with tools available to dynamically provision Kubernetes Local PVs.
+    The volumes are dynamically provisioned via PersistentVolumeClaims and are managed by a control plane component
+    called "maya", which also runs as a deployment in the K8s cluster. In addition to maya, a typical OpenEBS
+    installation comprises several other resources, which aid with various functionalities, ranging from snapshotting
+    to disk management. All these components are described briefly below:
+
+    * **Maya-API-Server** - A storage orchestrator which integrates into Kubernetes workflow to help provision
+      and manage OpenEBS Jiva & cStor (storage engine) volumes
+
+    * **Dynamic-OpenEBS-Provisioner** - A Kubernetes external storage provisioner that utilizes APIs exposed by maya-apiserver
+      to perform provision & delete operations of Jiva & cStor volumes
+
+    * **Dynamic-LocalPV-Provisioner** - A dynamic provisioner for Kubernetes Local PVs
+
+    * **OpenEBS-Snapshot-Operator** - A Kubernetes snapshot controller that creates & restores OpenEBS volume snapshots
+
+    * **Node-Disk-Manager** - A disk management controller which identifies available disks, maintains inventory, and
+      dynamically attaches/detaches disks to backend storage pods
+
+    The helm-based OpenEBS Operator eases the setup of all the above mentioned components, with a simple custom resource
+    provided to define the install options, thereby enabling applications to start using the OpenEBS storageclasses in
+    their PVCs. The OpenEBSInstallTemplate CR can be used to specify start-up parameters & also update/overwrite the
+    definitions post install.
+
+    ## Pre-Requisites
+
+    Before installing OpenEBS control plane, perform the following steps to ensure successful deployment of the Node-Disk-Manager
+    & the OpenEBS volume replicas, respectively.
+
+    * Configure the OpenEBS service account on the namespace/project selected to use the privileged security context constraint.
+
+      **Note**: The serviceaccount name is same as the one specified in the `spec.serviceAccount.name` field of the OpenEBSInstallTemplate CR.
+
+
+      ```
+      oc adm policy add-scc-to-user privileged system:serviceaccount:<project>:<serviceaccountname>
+      ```
+
+    * Configure the default service account on the namespace/project in which the volume replicas are deployed to use privileged
+      security context constraint.
+
+
+      ```
+      oc adm policy add-scc-to-user privileged system:serviceaccount:<project>:default
+      ```
+
+    ## Getting Started
+
+    * Try the quickstart [guide](https://github.com/openebs/helm-operator/blob/master/olm/README.md)
+
+    * To learn how to contribute, please read the [contribution guide](https://github.com/openebs/helm-operator/blob/master/CONTRIBUTING.md)
+
+    * OpenEBS welcomes your feedback and contributions in any form possible. [Join our Community](https://openebs.org/community)
+
+
+    ## License
+
+    OpenEBS is distributed under the
+    [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+  keywords:
+    - OpenEBS
+    - ContainerAttachedStorage
+  version: 2.10.0
+  maturity: alpha
+  maintainers:
+    - name: kmova
+      email: kiran.mova@openebs.io
+  minKubeVersion: 1.12.0
+  provider:
+    name: MayaData
+  replaces: openebsoperator.v1.5.0
+  links:
+    - name: OpenEBS Website
+      url: https://openebs.io
+    - name: Operator Source Code
+      url: https://github.com/openebs/helm-operator
+    - name: Install Instructions
+      url: https://github.com/openebs/helm-operator/blob/master/olm/README.md
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAfQAAAH0CAYAAADL1t+KAAAACXBIWXMAAAsTAAALEwEAmpwYAAA57mlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS42LWMwNjcgNzkuMTU3NzQ3LCAyMDE1LzAzLzMwLTIzOjQwOjQyICAgICAgICAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuYWRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIKICAgICAgICAgICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOmV4aWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vZXhpZi8xLjAvIj4KICAgICAgICAgPHhtcDpDcmVhdG9yVG9vbD5BZG9iZSBQaG90b3Nob3AgQ0MgMjAxNSAoV2luZG93cyk8L3htcDpDcmVhdG9yVG9vbD4KICAgICAgICAgPHhtcDpDcmVhdGVEYXRlPjIwMTgtMTItMTRUMDk6Mjg6MTEtMDg6MDA8L3htcDpDcmVhdGVEYXRlPgogICAgICAgICA8eG1wOk1vZGlmeURhdGU+MjAxOC0xMi0xNFQxMDowNzo1OS0wODowMDwveG1wOk1vZGlmeURhdGU+CiAgICAgICAgIDx4bXA6TWV0YWRhdGFEYXRlPjIwMTgtMTItMTRUMTA6MDc6NTktMDg6MDA8L3htcDpNZXRhZGF0YURhdGU+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgICAgICAgIDx4bXBNTTpJbnN0YW5jZUlEPnhtcC5paWQ6ZTA0ZWI3ZTctN2M0OC04YTQxLWE2ZWEtNjAzNWQ1NTE0MTkwPC94bXBNTTpJbnN0YW5jZUlEPgogICAgICAgICA8eG1wTU06RG9jdW1lbnRJRD5hZG9iZTpkb2NpZDpwaG90b3Nob3A6Mjc0N2U3YWQtZmZjYi0xMWU4LWE2NjYtOTc3NTg4YTJhYWE5PC94bXBNTTpEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06T3JpZ2luYWxEb2N1bWVudElEPnhtcC5kaWQ6NTMzOTc4NjctMDgxNS05NDQ0LWI4ZTItMjEzYzg4Nzg2Y2FhPC94bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ+CiAgICAgICAgIDx4bXBNTTpIaXN0b3J5PgogICAgICAgICAgICA8cmRmOlNlcT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+Y3JlYXRlZDwvc3RFdnQ6YWN0aW9uPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6aW5zdGFuY2VJRD54bXAuaWlkOjUzMzk3ODY3LTA4MTUtOTQ0NC1iOGUyLTIxM2M4ODc4NmNhYTwvc3RFdnQ6aW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OndoZW4+MjAxOC0xMi0xNFQwOToyODoxMS0wODowMDwvc3RFdnQ6d2hlbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OnNvZnR3YXJlQWdlbnQ+QWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKFdpbmRvd3MpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDplMDRlYjdlNy03YzQ4LThhNDEtYTZlYS02MDM1ZDU1MTQxOTA8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTgtMTItMTRUMTA6MDc6NTktMDg6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChXaW5kb3dzKTwvc3RFdnQ6c29mdHdhcmVBZ2VudD4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmNoYW5nZWQ+Lzwvc3RFdnQ6Y2hhbmdlZD4KICAgICAgICAgICAgICAgPC9yZGY6bGk+CiAgICAgICAgICAgIDwvcmRmOlNlcT4KICAgICAgICAgPC94bXBNTTpIaXN0b3J5PgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICAgICA8dGlmZjpYUmVzb2x1dGlvbj43MjAwMDAvMTAwMDA8L3RpZmY6WFJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjcyMDAwMC8xMDAwMDwvdGlmZjpZUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6UmVzb2x1dGlvblVuaXQ+MjwvdGlmZjpSZXNvbHV0aW9uVW5pdD4KICAgICAgICAgPGV4aWY6Q29sb3JTcGFjZT42NTUzNTwvZXhpZjpDb2xvclNwYWNlPgogICAgICAgICA8ZXhpZjpQaXhlbFhEaW1lbnNpb24+NTAwPC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjUwMDwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIAo8P3hwYWNrZXQgZW5kPSJ3Ij8+H6RUNQAAACBjSFJNAAB6JQAAgIMAAPn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAADGq0lEQVR42uydd5hkR3X23wo3dJ6ePJuzdrXKOQBKSCCyyCbKgG0w4PjZ2GCDA8bZYIIB2QRhgkgmJyEJJJSztFpJq81hZnfyTOe+t6rO90f3rnZXG6Z7umemZ+r3PPsIpO3bfevWrbfOqRMYEcFisVgsFktrw+0QWCwWi8ViBd1isVgsFosVdIvFYrFYLFbQLRaLxWKxWEG3WCwWi2W+IO0QzC/ecOklrfRzOwGcBuAcAF0Aykf9dwZAANgKYDOAHQDG7FO2zDACwDIAPQDaAUQB6KpBpABkAEwA6Acw1Eo39s277rZP1wq6xVL3wviC6p/zq2K+rCrcJyMAsBfAEwAeAHAbgHvskFqagAPgwuqfswCsB7CougF1j/OZbFXMDxy2AX0MwIMAxu2QWqygW+YDLoAXA3hD9Z/t07jO6uqfV1b/3QEA3wXwBQCP2KG2THOz+RIAbwHwIgCpGj+fqP5ZDeDSw/59WBX1XwH4EYB77VBbmgWzhWXmF3PI5X4xgHcBeDWAthn4vocBfBTA9+wssNRAF4D3Avj96v9uNvsAfB3AFwFsme2bty73+YUNirM0Eh/Au6sL1d0A3jFDYg5UzuH/DxV35xX2UVhOggvgn1Hx8nxkhsQcAJYA+HMATwO4C8BL7aOwWEG3zCU6APwjKgFrnwWwbhZ/yxpUztd/CCBtH43lGLwJwHBVWGdzDbwEwI+rm9Dr7GOxWEG3zCYJAB9HJRjoLwBE5tBve3nV+nqtfUyWKnEAPwfwNQDJOfS71qDiXdqMSsCoxWIF3TKj/DGAEQB/NIfnkQvg2wA+aR/XgucSAHtQCXibq5wK4HZU4kDa7SOzWEG3NJvno5IP/h84fgrPXOP9AG6FzepYqLwDlfPqVjmCeRWAQQBvs4/OYgXd0gwkgP8GcAeAlS34+68EcB8qRUEsC4e/RiWtsRXftxsB/ABz6yjLYgXd0uKcjUpRl3e1+H2cA+BOtI5nwTI9Pgzg71r8Hl4BYDeAM+3jtFhBt0yXP0Alx7t3Hm1O7rFWz7znQwD+dp7cSxeARwG81T5WixV0S718CcB/zsP7OgeVtDbL/ORdqBQZmm98BcDf2MdrsYJuqQWBSqnK6+fxPb4QlZx5y/x7rv89j+/vIwA+bx+zxQq6ZSokUXGxX74A7vXd1T+W+cEKVGr7z3d+F8C37OO2WEG3nIgYKiVbz1hA9/xZABfYR9/yCFSKsyQXyP2+DsB37GO3WEG3HAsHlaIWGxfgvd8IwLNToKW5AZWAx4XEazC/jxcsVtAtdfJ9AOcu0HtfD+DTdgq0LG9DpXjMQuRdAP7BTgELYCtnWSp8BpVe0E2HkQHTCjwsAUaBHaN9LzEGkh6M44H4jE3RdwH4KWz71VZjJYDPzcxXEZjR4EEJTAfPzl0igLHq3OUg6cJID8Q5wGbEZvoggO2otGS1WEG3LGDehUov6CaoNwPIgAcliHIOICLjRUl7CVZOLy4ax3O1E5FGemBkAMbBdAgRFkKZnyQnM+g4pTEQ50xF20DCqSyezd3Y/ArAhJ0WLcN/oZk1BRgDD0sQhQwYA6lIEuX04kBHU0I7EWnciDZutMxL2SgPyxBhIZCFSZLZEdcpThIzims3CuNGQUI2c/5+AZW2xXfZKWEF3bIwORuVs8fGL4JBEbKYgRHSBG19lFtxril2LacgvQRhLO2qWJoZJ8qIc1ROfp5d6JjREMVJ7k4OaX90l4kNPCmi+55gTnaEq2gbjBtp1sLYB+CfYCPfW4XfB/DiJqg4AEAUJyGCAsJkj5k85flU6FuvS53LeZjo5DqSYsQ4iHEOzj1mNEAEZhQTxUnmZEe1NzFg/OGdwh/eSf7YXi4yWW5cHyqSBJg4Ys43iG+gUlFu3E6NhQmj5lo8lhnmDZdeUstfvw8Ni/BmAANEKQtRzCBM9ujs8nNMfukZKPSu5WGqF0Y4nKmAcR2CqzJQXQSPtSEg6UI7PsjxwcOSjhzYatqe+Q1LbfkNk/kxESa6YKRbsewbz1Wo9FS3zF0WA3galZaoDYMYhyxlIIsZKnav0RPrX0DZFefxUscykHA4D0uMhyUwHR6auwwEqm4CwDhIOjDVIyMQGSc/ZvzhXRTr38xiex9n0cFtnOmQhfF2kPSAxs7hbwN4/VT/8jfvutvOJCvolnkg6B9Go0pjMg5ezkMWJlBuX2ImT7nMTK69hEqdywUxwUUpCxEWAWMOnTVOfYUlkBCouNxdExncqjse/THST/1KEuNMxTsavSACwCOoVJOzzF2+gkaWQmUMMBru5CCCVI8ZO/OlZnzDlRSkuqUo5ZgsZeuYvwSAw0gH2k+AhEMyP65j/ZuR2nY3S+x8kIlSloeJTpBwGzmPfxdTjH63gm4F3dL6gn4agE2NWASZ1nCyQ1CxNjN22ov0+MZrWKl9iRDlHJPFzBEBQ9MznSrXCWNpkPRMauvduufu/2WR4Z0ySPWAuGi0G/4PYfuoz1WuAnBLw6xyziGLWYhiliY2XKaHLnoTit2rhJMbY7ycb8z8Pbg5lS7CWBqMyMQGnjTpJ26m1DO/EcxoHsY7q3En057HWVTST/daQbeCbpn/gv59AK+c9iJYyECUczS57lI9dMEbUeg7RchiholipnoMyRp/g0QgLhCkeuHkR9WiX/83pZ+8VYaxNNNurJEu+BEA62DPI+ci9wC4qDErIIeTHYaRrh689G165OxXSK7KXObGmjqHwUVlcyock9j5gO6+75s8tncTV4kOZpxII6z1rwN4sxV0K+iW+S3or8K0UrMqZ+VOZgjai5vBS9+qR8+4VnCtuMyNNm8RfM7ENQijaRjHM90PfEf13P2/wkhPqGgKzDRM1P8dwP+zs2pO8XYAX27MJGJwJwdRbutV/Vf/IWVXnCPdyUHGVHlm0s2qm9Mw2QURFHXX/d/WXQ99TxLnPIylGzGPXwLgZ1bQraBb5q+g3wXgkvpmCwOMgTd5AIXetWrf1X9Ahb71jpsZwowtgkcsiAbG8REme0z6qdvCJb/4hAujWZjoaJSoE4BTAGy1M2tOwAE8WX0m08ad2I/C4lPVnpd+wATJbtedPPDspnVGF2ED7cUQxjtMastv1JJfflKIUk4Eqe7pzuM7ATzfCvrCekEsC4c3TkfMmVZwJwZocu2l4c7X/AMrdq9xvLF9YDqYeTEHKsF4YRneeD8fO/Uqd/crPqTJ8YyTGwM15vcwVM7SLXOD9zdGzBm88X7kVpxtdl73tyyMd7juxP7q42YzflPEOHi5AG+8n0+ue5678zUf1UGqV7kTB6Y7j58H4E122lhBt8xP/qjeBZBpDSczhNGzXx7uftlfMhKO8Cb2VwOG2OzdEWMAafije1hmxXly9ys+pElI4+THK5W6ps97USkNa5ldGID3NWK+uJP7kV15rtn9sg8SCVe4mcHZ2ZA+Zx4TvLG9KHavdndd9zcmaFuk3MzQdEX9L+zUsYJumX+8GMCFddoQcCYPYOLUq8r9V/8h52FRykLDBLNBaz3gTQwgu+wsueelHzDEYGQh06iF+o/t9Jl13gVgzXQtYXdiP/KLT1W7X/5XRNITTm4ExMQc2rZweOMDKKcXu3te9hdGezHtFManI+qno9LExWIF3TKPqKt5BTEONzOI3Ipz1L6r3ydFKStlKdsol3bD8cYHWGb1JWLgyveGPCgaHhYbkXb02wBW2Sk0q7x/2mKeHUa5fYna+5I/JyM94WSHK+mOcwzilY1HsXed23/NHxgYo0UwrXn8O3b6WEG3zB/W1LVLZwyyMIEw0aUGrnovEZdCFifnrJgf9Ca44/vY2OnXOMMXvl452RHC9APkHFRc75bZ4Y1VS7NOq5dBlrIw0tP7rvkjChLdjpsdmpNifvhvdicGMHHKZWLkvFdrJzcynfz0F6FRaX4WK+iWObEg1vysmdHgYZEOPO/tpti5XDrZ4Tku5gDAwIyGkxvlgxe/iWdWX6TczGAjfve7AHTZqTQrTKs1aqU3QIYOXPo2nVt2lnQzB1pgHgMwBk52mA9d+HqRW3HudM/T32KnkRV0y/zgDbWvghxOZhiTp1ymxjdcKd3JQQbWItOFMYigABgjBy7/XQTJHi0LE9N1vSerom6ZWc4FcHX9c4HDmRzExKlXqNGzXibcyQOsZe68Oo+JO+LApW8l7UaMCIqoMwj1NWhmVzqLFXTLjHAZKqVea5sYQQEqktQj57wKTIec6aClbpoYh5MbQalzuTN08ZuMCArEtJruZa/HrIb0L0jePi1BLEwiSPXowYvfwrgqC6bKLfUIqVrJLrfkdDl2xku0zI/W+/N70ZTOdBYr6JaZ5BX1LIRObgwTG64w+UUbhJMbRctY50dZZ+7kIMY2vpBNnvL80MkOT/c+1qFSac8yMyRROS6qD2MgyjkavvANptSxTMj8WGvOYyLI4iQbPfOlKHeuUKKYqXdT8mo7paygW1qbF9VunRcRJjv1+KlXMhEUeBP6Ns+cpusQXCs5dMHroaJtmpfz07XQ3mqn1IzxGtQbt8A4nOwQMmsu0mMbr+FuZoi1pJgf9DQUsyinF8nxjVeRLGWpzil8TXWTZLGCbmlBzkGl61JNi4csTGBy1UW62LOGy8IEWtrLzBhkbhSF3lOc0TNfSrIwPt3beSWAtXZqzQi/VffCFhZh3JgZPv+1BMYEV+XWHgnG4OTH2cS6F7Bi50pdsdJrphvAxXZaWUG3tCZX1W7RKmgvrjNrLwHTuqWt82dvCpD5cTZ65ktYsWetlvnx6QTIcUzHDWyZKqei3mA4xuFkRzB+2tUqt+RM0RrZGVOYeOU8ym2LxOS655Eo5+qdw1fYqWUF3dKaPK9W5ZOFCRQWbTCFRRta3zo/7L5EOQcV7+RjZ75U86BI02xP+Xo7tZrO6+p+1sUMyuklevSMlzBZynDMlwZUjEGUcyyz6kIKE92ah6V6rnK5nVpW0C2thwPg7No+QmBaIbvyXNJeTDAdzp/RYBwyN8Im1j1f5Jecrp3ctKz006yl03Suq1PPIUoZGjv9RbrUuVyK4mQjKgXOGWQpi1L3KpFbeoapc8N9Cmw9BSvolpbjfABLa5oMQRFBW5/KLTmDiWKWzaeFEAB4WIL242L0zJcQSJtpVpB7rZ1iTeNiAGfWZZ0XJlHsWaPHN76QOfnx1g2EOx7GgLgQuWVnETFRj6eprb6xtVhBt8wmtQXDoVIeM79koym3L+EiyM+/EWEcTm4UmdUX8vzSM4yTH5uO9fYyAL6dZk3h5fV9jCDLeZrYcBUFyS5ZyWiYb3OYQRYzKPSdwsrtS7QICvVc5Sw7xaygW1rPyqlpMSTGKL9oI0hIMW/OHY9eD1UZxo2J8Y1XEyMiGF3vpZahjqBDS7MEnUEWK9b5xCnPr1rn87MGEA+LCJPdvNi92vCyFXSLFfSFwMqaJoIqI0x0mWL3KiZK+fk7KtUKcpmV5/Hc4lO1k5+YjpX+SjvNGs6lqKOyIQCIcoHGN1xBQbJH1Cl0rQERjHB5sXctY/Vlodi0SyvolhYiBuCMmhbDUg6ljmU6aFvEeFic14PDVADtJ8TkKZcZpgOahjfiJQDcub6BYSoADwqtUiWtLne7KGVR6liuJ9dcAlmYmLfW+bMb8BIrda4wKpJUdQSvrgOQsMukFXRLa9AHoL2mTxiNUudKpt2oYEbN79FhDLIwjszqCyt56YXJeq+0GMDz5/CNVmryx9pQ7lgGmR8D8Tn/yl9bz/MUpQwm115KQXqxFOX8vH/BeVBCkOwVQaoXPKy5aE4bKkVmLFbQLS3A+tr+OoGEQ+X2JZqRYQuh/wgPSggTnXJy3aWm4pGo+55fOpc3LpUCK9dgz0s/ACM9yGJ2LqdxnYsaPUuHnmWy10yuvYTxcm7eW+cAwHUAFUtTOb1Y8/oC41bZZdIKuqV1LPSpr/taQUeSJkx2y1brqjYdsROlHMusuogFbX31LooA8MK5eHvEBdyJAeSWn4Wx01+MUtdqDJ//Wsj8GOZwwONL6nmOsjCG7MpzdLFnDZP1lURtPYhAQjphokuAsXoe6GK7TFpBt7QGi2qaBGEJYbxDB8kezYPighkkUcqi1LVcZFaeb6bRL/10zMG8XlHOQ0VS2P/8d8AIB/7Qdoyc80pk1lyCBnSdaxbX1KznWsE4UZNZfRGY0fM2O+PYom4QtPWFJJx64kDSAKJ2qbSCbpn7LKtpUTQa2k+4xvE9Nr1iK622IoKpkGdXng/txfU0KuPNrfS1ai3zzOoLkV96OtzJA+A6AHGBwYveCJIu2NxrVrIGdZUqnkR+0QadX3QqrzTeWUDt6omgoqmIkS5nNRSYYQwgoj6tjT1Ht4JuaQFqcqcxrRAku/LG8UJGC0nQD9auX8/zizeYSnBcXYJw9Zx6qct5BG29GD3zpah4HjiIcbiZIeQXb8TkmkvgZobmWsOSK+vakOmAsqvOJ+0nBVPhgnrJuSpDRdvKOpIKatmMEgFE1ME5S9ul0gq6ZW7jAkjVZqEraD8pjONxLChBP9RdTuRWng+mFdXZXe581JpV0EzrPD+GifVXIL/kNIhi9oiVXJQLGD7/tQiSPZClLOZQAGTN5+eVUsWLdG7ZWUyUsgvLOgfAVAjlJ7X2YobpqWem5IplLO3pWHPZOafYfHQr6JY5TheAjtpWBgbj+D7AxIIbLcYgSlnklp3FyulFps4Ygg4AF8wd67wP46deWbXOj7xXWZxAqWslJta/AJXSqHPizDkN4JKavSulDHJLTqNy+1IhyrmFN3XJgKQbIel6tXjWjDFIJ6Mru9OJU+xyaQXdMreJo1JYZmoQgbgD40TA6i+D2tKIch7l9iU8v+R0U4mSrsvSe8GcsM5zIxhffxmK3atxvCMEXi5gfOPV0NFUPTnMzeAi1NoBjAxIOCa3/GwQY3xBBcM9OwggLph2fFaLZ42BQSkdlAMVwGIF3TKn8QF4tezyjXSU9mPFheZuP3xhBMBzy8+GcTwDqmtjM+uCzst5lDuWYeLUqyrudHZ8y7acXozcsrNQCSSb9WXgRbVvwnIoda4whUWnVlLVFpi7/dnNuCTjRHQd7y5hjrhnLFbQLccnUbXSa7DsGJGQemFaORWRE4c6WC01dVYaOxOzXH1LFieRW3YWSh3LIE4U4FfNZBg7/cXQfgJzoPbAZTU/r3Ie+cWnUZDs5jwsLdB9KIGEVMaLFhdWdorFCvrCoacWC/3gwgBj2IJ+EcISgkQ3zy8+leoU9DgqruNZ2pNwMDIo9K6tCPmJLFbG4ORGkVt2JjIrz6vmpc/a41+HGrt/MaNg3KjJLT0DTCu+sA1NAogYFvTba7GCPn/ptUNQ38LIyPD84tPIOL6pM31vlgSdwckOI7viPGTWXAonPza1TRyA3LKzQFxiFo9bLqn1A6KcQ7FzhSl2r2ayVHfMw/wSdYvFCvq8xPre6hRFUcqg2LOal9uXGl6flX7ebHoYJtdegiDZhSlF6let9OzK81HsWVup8T471FaUh1UazhQWn2rCeAefgwVyLBYr6JZZfKaMAZwv+G0+D8sIk928sGiDFuV8PW7oizAL+eiilEWxZw2yK8+DOzkI4lPLPmSqDBXvQH7RBlTyuGd8ORA1W+hGw7gxU1h0KjHS3FrnDGCCrJFusYI+P9ld85JgNGdh4CzISOGjIfB834ZKtHvtgUYJAKfN7HpezaNfcgaCZA9q7WXPdID8srOgvRhmoW3uqaix65coF1BOLzHFrlVclLILe64yBqaV4EHeb4G2uBYr6JY6GAEw5dZhxDiYVkKU8x64WPCDJ8p5lLpX8SDZY+qMnj5/Rtd0raD9BCbXXQpWc1rxweC4s5BbeiZkbnSmh/t5NT+fII9izxoTJjv5HMmhn11BN4rzoCRr9a4wxgRjzL7wVtAtc5wsgFyNiwK4Ks212t6z80KEJQSpHl7qXEF1Vh+b0cA4WZhAsWcNSl2rIIt11KI3BtqNIL/kNDAdznS0+6W1/fVK3nWhdx0IXNhgMAaQAddBTc/NkAHnXEd8V8NiBd0yp6m9YAQRuAoCAPYFJw0jPVHsPQWM6krMP3VGLTQVILfsTKhIAnV1i6v0hUd+6ekIE90z3YWtJm8GD8sIEl262L2aiyCPBX9+XnG5hywsq1o2477nYt/Q2FMPPb3rEbtcWkG3zG0KqMHlDgDEBXhQKDMdanuOzsDDEordq0lFUzU1vThM0DfMyMsbFBG09WFyzSWQhUzdQW2yOIF83wZkV54LNzNjOelnoZKDPmVEOY9y53IK2vpQZ839+bX35AIiLJW5DoJann3EczAykQsffWavLf1qBd0yx8mgFpd7dWFwcmNRHpYc63YHRFBAOb2Yl9sWkwgK9Vxi3Uz8TlnMIL/0DATpxZhWcxICGGnklp0F4/jAzFQdO7vmrZYOUepcCe1F+ULtO3A4RjgQhcmIKOU8Es7UP2cIjhST8YiXhcUKumVOM1kV9RpmgYQoTorKWZydEkyHULE2XupcbipR43WlrzXZPDMgzjG59pJK7MN0yvYyBic7iuyKc1FYtL56Ft90LqzpJxoD40Z0sXsVMa3tJAVAwoEo54Qo5wUJ2fSNv8UKumXm0agExtVgoXPwsFTiQalINtK92vRC8FLXSgCc6qjVc3rTrfNSFvm+DSj0rIVTGJu2m5zpECqSQr7v1Iq13/yNXU3550yVECS6qdy+hFXOzy1gDCIo5JlWhmrfdGZqXScsVtAts8OB2nb6LmRxUsr8mGuka0cPlfPpUvtShLG2es7Rz0KlaEqTFnIOUcwis/oihMkesEakb7FK7EBu+VlQ0XR9AXZTpwfA6lo+IIICyu1LKYh3sgWfrnYYTm5UMNL17OYGUUlxtVhBt8xxhmr5y0ZIiFJWyOIkIyvolRcjLCFM9fIw2WvqCMBaDOCU5m02Cii3L0F+6RmQhYmGWdNOfgy5pWcgt+xMONkRNDGK/EIA0Zo+YQyVOpcbciNi4bb5fc4uDE52xGM6ZHV4aLIAQjuGVtAtc599tS4MTGuShUzJDl31xVABwmgbK7UvQp0FZprjdj+sU1qh7xSIYqZx1yYCGEd2+TnV8rFNE87Tav1dJD2UO5ZyENlyhqgWhFLlQBQni1RffZgDdhStoFtag9pKflUrTrmT+6O2NvZhi6aQvNy+zICxeiLOzmqKnmsFFUkiu/I88LDc2MfFGGRhAtlVF1R6qpeaFjNVU0AcV2WoWLsqty0mXl/WwTycmw5kMeO4mSHfOH49lxi0o2gF3dIa7Kl5LSeCLEyUQTq0ol4dE6NZuX2JMG6U6kiTaoKFziCLkyh1rkBu2dmQxQk0+lnxsIQw3o7cirMhyk0RT4Eai+/wsIxyqoeFiU7BbXe1g5tNiFK2LIuTupaUtSol1OzFs1hBt8wWu1Cjv9Q4PpzMMJeFDCPp2BFEJRAraOvTYaxd114nHRsANHggCUwrZFZfCO1GUUew3pS+g6sQmdWXQHvRZgTHrQSwpjZBLyJo69PaTxDTNv8cAIz04GaGuChleR0pa2OwEe5W0C0tw1j1Tw0LhAsnNypEKUvEpR1BHEzlanPCZBerwzJcBWBZw63nWBq5FedBNM31zCCKkyh1Lkdu2VmQjTyjr3BWbfsLAnFpgrY+RoxLW7+9OizSISc7ykQ5L+pINd0FwFaJs4JuaREKALbVtEBwCVHOGSc3qm3q2kFBV1CRhCm3LdKzHhjHGGRhsnK+3b5kepXhpnTfSWRWXVip7d7YUrA1udsZEYzrU7ltkeHaBmUfnAtMheRkDug6KzvusYNoBd3SWuysSdCFhChmHDdzwDGOZ82gZ1dPGSa7OXFp6qjG1rje6EQA58iuOBckZHPLs1Yj6fNLT0Oxt8GR9MCZtW0uygijaRMmukQdxx7z0zoHA9cBeZMHZJ0pizYgzgq6pcXYW8+HnMxwwIwmGxh3UFBCBG19xrg+WO2CvrFRv8PJjyG35HTklp4BJzfa9AYqPCig3LGs0ic9P9HIynHra/odYQkq0UVhvIPq9JLMP0GXLmR+wji5UWOkV88lNttRtIJuaS0erX02CHgTAy4Py2S7rlWHRIcIY+1S+UmqI0CsQYJeaZM6seEKqGgbZsRSZRyimEF21fkIUz1gjRHTpagExU39ZxiNINHJjRtxGNmAOKAawJobgZMdlnWmrO22o2gF3TLPLXQjXTiZYS0Lk/Yc/TALMUx0qjDRpSqNWmoWsM7pW8t5lDqWIb9oA2R+fMYa6MhiFvlFG1DoXQsnP94Ir8BqAJHaPCQKQVufMtKjaTWgmU8WunDgTh4wPCgQcXuGbrGCvhB4GsBEbTv/CNzssHSyw6zOnf+8gxkN40Q8FW1z68hFb0ONLubn/oDKeXZ21QUoda2EKM9gYxIyABfIrLkExBgaIKi1lcMlAkmXVKzdZSC7Vh0cFi60N7mf87As6tjc7QbwjB1FK+iW1mIEQH9tCwUHL+fJnTxg6ihWMU9XT4JxfB209RWZqSvve+V0vp7pECqaRm7ZWeBBccZDG2RuDJNrL0Fh8UbI/Nh0L3dGbZspBeUnVJDqLdvz80NiDlHOwx0fAIm6vGj70cSavhYr6Jbm8Xht6sHBVVl44/sYcW4PLCtLKIhzHsbb/TrV9NxpyDmc3BjyS06rBsONYaYVnekQyk8it/TMSuW46bn7l9X23Qraj0sVTfnMpqxVZqNwIIuT2p08wIxTV0DcQ3YUraBbWpOnav2AkS688X6Ich62N3r1JQnLLEx0l5WfCOuozlZ/cRkGwGhkl58FEg5mpcsYY5DFDCY2XI5i9yrw+l3+AjWmrHFVQpjoLqlIMrSCXn0/3Sjcif3cyY7UK+i77ChaQbe0Jk/UbAFIH87kASbz47pOl968g+kQYbxDGC/GZ7KmuyxMIL/kNEyuvwKyMI7ZyjwQpUylfvzyc+DkRur9HR0AumoT9BBhtE1qLy6aU+a2BQVdSHjjA1qUc7zOio4P2lG0gm5pTZ6secFwPLjZEe5NDEB7UTuCqJzlai8qVKSu1LU+AO21fymHKEwiv/QMBIlO1NGTvaFWOg/yyC4/GyrWAabqspY3AKgp0pIYJxVLM4BZV9HBR0HGeGN7OIypZ1dF1kK3gm5pXXbW+gITF+BBgXuje8i63J+1FFUkpcNEV8hVzcFZMdQR6c6DIoK2PmRWnl9NGZvNV5VB5ieQX3YmCr1r6/UW1BgcSCDOKUj1lG1NhOqICAeimDXe2F6i+tJKH7eCPr+xXTjmNwGALQBW1LqC+8O7OVehAmNywef/kgE5nqsiSbD6Sq6uAXB3LRaxkxvB8HmvRn7JRnjj/agzGK4PwGVV6zgJYByVdMZfAxiq0TKEES6yK89DYmddXtvaBJ0IJByu/WTUNmSpYBwP3tg+cif2C+PW5T3bbkfRCrqltXkQwItqWzh8eOP7IAvjMNKD7UENgIAw0VkiLjyAWI0Cu7y2ldvAOD5yS88Er+/s+FQA/wTg5Sf4O98F8OcAdkx5sShMYGL95Wh7+tfwR/dARVK1/Kaa6tpzHUJHkqGKpQ0Py56dgJWAOG98HzmFCRZG2+q5xO12FOc31uU+/3msdksgAjdzgHsT+41xI3YEq1ZzGO9End2tasq/dvJjyC4/B7nlZ0NmR2q1zj+ESq3ul5/k772marH9xZQXi7CIMNGJ/NIzIYrZWo8BemoabhVC+wkKY+2wTVkOOi3I+EM7wVTA6wwrsAVlrKBbWpwHUGMhCRISspAR3uhuZhzf+jsBgAy0F/NJuqwOt3vf1JWMHzo/114UNUbVfxzAR2v8bf9Ytean9NtkYRIT656PUudy8Kn3ZI+h1hrupKG9mEuO5zGydVCIS8hS1viju3mlIUvNr2UOwP32RbaCbmltdqEGt+qhBYRxRIa2gyvbqKVinZah4h1FFW0r1xHpvgpAfGrfU0I5vQiTay6GKOVrCT57J4A/qvP2PgDg3bVY6SqSAp+65byo+mfqgq5DhImugnYiIYytcWTcCNzMIHkTA6zO8/PHAYzBYgXd0vLcXesHjBuBP7IbMjeq62zROK9gOoSKJIV2o7yOnOi+qQpaxTpfVGvd9h4A/zbNW/woppJeVz3fL3csBdNTFvTe2sdbQUVSwrg+txZ65X30RveQzI2yOhsnPWyXQSvolvnBA3VZBJMHpD+6x+ajoxrlLV3XeLF623hOSdCJC4igAFEuoIZOWu9BpRHMdOgA8K6TjoPR0F4M5bZFtZxtr6ntpxCIcWg/5qFSYW7BQ2A6MrSDcRXwOj1mNiDOCrploQo6cQFRyjF/aAeRcGnBpw6RgXF8Fcbbi3VWLVs7pRcyLKLQuw4qlq4lwv2lDbrLV518Z8PAjAYPy7UExa2oafNkqmMd6yjYCnEH67dPGH94Bxmn7iDVTXYZtIJumR88jErbxBoXEonI8HbGg6JZ6EVmqiIDFUmhzrriU6rpzrRCmOiCdiOY4tnxSgDnNeg211ct9UazqMaZBxIOU9FUPaV25x3ai8Ib2wdvbJ+o01u2CZV6FBYr6JZ5QAjgkdoXkhj8kd3cndxvpmEZzBc7CWBcGicSqbPIy9Kp7RwYmA7ByEw1IK6ngTeZxnSayZx40zF1jAFJVxg34sOen8M4PkWGdsApToo62xr/xi6BVtAt84s7a19IPLiZYR4Z2m60F1vwA8iMgoqmlJGuqUNo1k75b5JBDdX5Gt24vhnFppbW8pe5DqEiqVB7ccUXfJc1BqYCExncOp1TrzthsYJumVf8pp7pwUzIovufASOz4E0lZjRUvL1IjqfriLyekiVt3Ahi/U/ByY1hitbYcANvUQEYnYoXAVxgigqTQo3NaaoZBYH2E8FCP0M3rg83M6QjQzvqDU4lK+hW0C3zj0dR8zk6QbtRRAa3Cic3ahZ8+hoRtBuNEBeyDmupC0D3lCwyHVZ70U/pS7ahcTW6d2IqNQuIqnEEUzoSWAKgs9aNEzlexDiev9Bz0LUXhz+8k7kTA6LOqo13A9hrlz8r6Jb5RQDgntothCi88X3cH95J2o8v6AFkRsNITxrpsTpS15KYwvm0dny42SH4o7uh3SkdcygAv2zQLd5yUi0XDpzcKGIDT2KKBU4W1f4zCNqNcWKCL/SSRsS5ie7fQlyVONVX7vUOu/RZQbfMT2pe+IkLiHKORw48AxLOgna7M6Ng3Gg4DVfwSS10cny44/1Ibrsb2o9N9Sz9yw26xS+edPcQScIb3QN/eCemGFfRXfOvIEBFkyVwbhZyuiRJF05uzEQHt1arw9U1FrfZZc8KumV+Ule0q5E+ovu3kCxOahILt0Ef0wrai4Xajwd1pq4tPvkqbmDcKNyJ/RClHKaYLngfgBumeXufQaUz34l/m+PDG9sLUZ7yb1tRl4UeSQXEBS3k1r3VLBPjje7hdQalDsGen1tBt8xbtqKOEpDajyMysov7I7tJewvY7U4GxvE8I12/zvzoVVP5SyqaQmzgKXhj+6DiHZhiRP27UUcBoSp3AXjfSW9fOOBBEYldD6EG92/Ngs6IYKQXJS4W7vpEBOP4FN3/FGRxUhCvayN9G4CSXfasoFvmL7fU+gESDmR+XEYHnoJxIwvWamJEAOPCSK9eN8WSKY03d8CDAtqfuLn6lk7p6wjA5ai9bv9tAK6cymYmTPagffMtSO58AGFiynFu7TXONhAXMI4vGdGCPUInISGKWR0deKre2u0AcKtd7qygW+Y3dQVQkXAQ63+CiVLOLFy3O4G4IB1J6jrPM9un+j0q1oGOR3+M5LZ7ECS7p2qlFwBcCuAvAQSkFWS8DX7Pcridi+GkewCwg9cqAfgTAFehEjB5QowTgcyPI/3ELyrpdFOvJ76klgFixsBIj7QbJSzglDXtJxEZ3o7I4DauI8m6LgF7fm4F3TLvuQfAQK0fUpEEIoPbuD+802g/sWAHj7gwyk8U64zVmnLENwkBcIH2zTdX0thEDVYa0T8B6I6tOv2t+Z2b7tn7rX/D8K9vwsSjv8q56e4bmeO9BUSdqPRPn4LIagRtvUhtuxOxgacQxtqnGqznoNZOa2RA0g2NFynW2QRnXmwcjetTZP8zJOuvDncn6mibbGltpB2CBUcelc5Lv1Wbhe7Cye0Xsf7NJr/kNAKI1VkCtYXXWQIYxzQijnsA+JjKuSYRgkQX4rseRnLHfZhc93y44/0nbohCBCYknLZuiEhscvi2b3x1x//+fbI8OXoxq/ziR1e98c+uX/rGD6A8tBdhdhzspB3dCGEsjcjQdnQ9+H9QkWTFyp96UZmaotwrXe08Y9yoWah13IlLiGLGxPufYCRd1HnE9UtYrKBbFgQ/q1XQAQJJF7H+JyBKLzHEpViICy4xzkk4EUZ1u9zjmGqgEucg4aDrN1+BWnUe+KozwYrZ44uhkFCFLLJbH8bgzV/C0P03gwHSdV2QMdBKiR03/SvyuzZj2Zs+iNiKU6FykyCtjutCZ1xA+Ul0/Pp/4A/tQLF7NWp47p3VDUxNmyYSUhrpMyzQ4oTaTyC6f4uJHtjCVf3esJ/aZc4KumVhcAsq56Y1RdsoP4HI0Hbuj+wyxZ61QhYmFtzAMRAzjieereRWk5fCq4rcyFTFTcXSaCuOYe/X/xrbvB5ETfn4+u/6KOx8HBNbHoJWCo7jgAsBIgITAo6U0Eph8N6fIrvjcbSfezVSp14M7kVBx+ltHkoPySCH9J6HEaR6UeMmrvaiMkQgxiUJIdmCzEEnGDdC0YEnSeQnhG7rq+ciD6OOZkwWK+iW1mQ/gF8BeFFNS41w4EzuF/G9m1R+6RmEwvjCc7sbDSN9kHDAiECs5vvvAvB0Des7RFsXsk/ci/HBYYyfdMMBSCEgfR9EBDrMk0BE4ELAFQKl4X7s+9mXsP9nXzrhE1QATu3pRPzUDZhkAjU2palZjaoudxCXWIjZFJXe5xkd73+CGcev9zI32yXOCrplYfHjWgUdqBSZie17nIvCSzUJV7IF1g2LGQ3jRkpGugLGOKg9VbrGfuMEAgP3Kou7602tnj6dRAylW3HOkAoBmON7GjQB0gFxB6BirffaXt/4RrWRLmNkFlzQrookEd+7yUQObBV1RrcDwA/s8rYwsVHuC5efoZLaUhM6kkRkaLuIHXiGVP0LTgubUAbGjWgSjqmzV3fXnNqgSAdMemDSPeYfAED9aYq9NX/CaBgvWiLphgvvDJ1AwqXYnscgStl6i8lsAnCvXd6soFsWFttRcbvXtuQICVHK8tieR6u13ReWW5QZDeP4ZIQDVp+gL6RSezULOiMN4/gwwkWdG6aWxUgPTm5EJ/Y+zqeRSWHd7VbQLQuUH9ZuRBC0F0d87+NwM0N6Gud8rWtFceGAc1HnBbpb7Y6NrltY++qZX0a6nLhgCy0oTkdSiPU/afzhHTa63WIF3VIzP0HlALW2hcePwx/eJWL9TxgVSWEhWemMCMSlR4zLOoO2OlrlXokIYAypWAymPms5Xfv4GhAXEXDhLsCgOB3f9TCYDjl4XUvzZtjqcFbQLQuWHXUtAIyDGc3jux5mzBh9wmIn89RKnwZtM/6N9VrmRBBSojMRhzbNLHX7nAm24F5E7cXhje7RsX2buIqk6o3w/5Fd0qygWxY2dbndVTSF+N7HuT+8w2h/AR0LV9OqjBtFnaVJ6wqKo1mwVhljMEQIta5HYtP1CDoxUe2zvoCscyLoSJISex6FNzEgjBuZuXfZYgXdMu8EvWZ/qnEicDJDMrHnEdJeYuF0YCMAjIE4r9eKqrmxtTYGvakUIARM64xzO+pI0avuJBbUC0jSgShldWLng4ykW29th8dQ6dNgsYJuWcDsBvDzepTNuD4Sux5isjChqf4Wj60Fq1jpzOh6hacNNa7YhghR1wXnfFYs9TpJomZlYocs1gUk51CRFKIDT1Fk/xYxjZiU79ulzGIF3QIA367nQzqSQuTAVhHbt8moaNuCWIgZEUg4xji+YvXlSSdQY+oaA6CMqZRwbR3rtfbzcyIQ50b7idLCefUYwIVJ7rgPIsjzabQm/q5dxixW0C1ApbLUWM3rLxfgYZknt99XabK9EFylxoCkFxo3VkK1rjkBEJxPVWxTVeu1hjWfVcROKRgVzIxLmjEYFYCUqnaZq/k760vPY5xIOuFCOULXXgzu2D4d3/Uw05FkvZvi36BSUMZiBd1iwTgqpWBrtqhUNIX47keYP7xTL4jKcRWXO0O1LCkBcDhHoBSFSk1F1CNVUa/pS5kOK19NQFAqISiXYab2fTWJOBEhLJcRlEogqiwQPCyijnPd+gSdiIFoYaxLlWA4JHc9ZLyJfqHdaL1X+pZdwiyAreVuOXJReFvNBqsTgTsxIJM7HwgGe9cRCpNsIQU1ccZAIGw9cCC3rLMz4jmO1Ce3sqYeGMcY1NgAvMWnYONbPg61fzvyWx9GYc9mTDz9IMqlEiTnEK5b9/k6YwxGa4RhZdMQ7V2G5PoL0XbO1WB9a8DvvhF6+91AoqsWC7LbvlIn0XPpQhYmdGL7vdxIn9XQZ/5wAtjzc4sVdMtR/BzANgBralyWYLwoEjvu52OnvUgb15c8LC+YQYu6LrYPDpmB8QmzccmSqS7HU09dIwIFJWRPvwbeqjOR7FuBrktfBV3IILv9MQz94osYeeDmirBLASGdqQs7Y4AxKJfL4NJB2+rTED/lAix+1fvhJDpAYQmlSBvyo89D+ulf1eoOTthX6sTPNYy1o23rXSY68LTQsTbUGQz3EwD77IBarKBbDkdXrfQP1vpB5ScRGdwm4rseUuOnvQjuxMCCST0SnNP2oSEqKyUl5xTqKeWmHzNgzBAh5nnwHAemGnDnFicwtPYijK26EHL/dgRGAdgPxgQSa85C22lfQO+T9+DAz7+Ioft+Dq003Grr1JNZ5VqFUEojsXg1lr7uTxBfey5MUAQXEqUDOyoCLgaRWX428ivOQax/M8KpW+k99pU6kWuHg5HRya13Mm5Crrio9/z8JjuYlkPTyg6BZdqLA+MAGEttu4fxsKSnEanbUniOg7FcTvePjjLfdfhUl2MGtHPGcPgfBiDue9g7NoY7n96Ch3buwkM7duKeLVuwc+n5kIl2MB0cugKRQTC6H8X+bYitOgPr//KrWPuuf4CQAuVSCTDmhJuqoFSCUhq9l7wMp//Dj9H1gtehPLQH5eF90OXCIQue6RDaT2B849VgWtciOp32dTrBJjjahuj+p018z2M8jLXXK+b7YYvJWKygW47DJtTRgQ0gqFga8b2Ps9i+J7SKpjH/K30RfEdi79iYARF3pZzSDTPGwDnvNUQ4/I8QAuVQ4cFt2/Hk3r14ZMcOPLJzJx4ZzWM81IgIjueU2GUMYAzB6H4Udj+J7qvegjP/+ZdILFmNIAxBWj1H1BmAoFwGA7D2HX+HtX/839ClAgr92w7Vbj96s+ZkRzC59hLklp0BJzeKKQbIpe3rdPy5Y6RvUlvvJpkf49Oo4fBdACU7npaDWJe75Wi+CuCKmpcoIcGDgkhtvVPnVpytASbm8yBxxlkpVNg9OnpwjZ6SoPuOxPbBoXj/+Dh8x6l8lAgR18VYPo9MqQTX86rXJARBAGk06EQ574yBtEZxYDu8jkU4/R9+jF03/g0GbvsmhNaQrgcCQMYgCALEF63Cuj/4FKLLTkVp/w6QKoN70eNa9EyVoZPdmNhwJeJ7HpvqZq2+JjSMERif131TtZeAN7pbJ7bfy3X9ddsB4Ot2ubJYC91yIr4HYKR2o4Ogom1I7HyARwa3zd8ubJXSrxRxXQxlMnpoMjPlYAFXSmQKJewaG8uWySAXhsiFIYpaY7RQRP/YBISocx/EGBjnKI/2w5RLWP3u/8DSa6+HNqTLpRKCUglhEOiOM5+HDR/4MqLLN6J0YBdIBThpcx3G4eTHkV+8EeX0Yohy/mS/JoE6StxWxtcwpsrOvO3PUk1VS227B974PqG9uvsg3A9b6tViLXTLSRhHpXLce2r9oHEj8Mb6ZeqZO8P8Ze8iWZyYf8tyJRmcSc6pf3ycoLWcSgAgAfCkxONDe9CdTret6u1FKQhAREhEo9g3MoI9g4NwqlZ73T+PC4TZcZigtHzlu/456XWveN7wHd8Cczz4PSuWrX73v72OgvIzxf5tTzMhp5yOwMt5lNqXYuKUy9B7143QfgI4fkvVdtQT5c4YmDFcFHP+fH25jBeBkx1Sqa13MePFp/N+fNUuVRYr6Jap8LV6BP1goZnk9nv52OnXKBVJOVOw5lrLwGICjgndYmaU909mn63FepKl2RUCE/m82Tc+zk9fubKXjAEDwKtNXnbuPwBMr7RrFMArAbyUcX6xCYqrCnufRtfzr0P3lW+onI8TLQtGBr5lVAgm5ASARwDcDOA7qKQsnlBsZSmDiVOvRPqpWyFK2WpXtGPSAaD+4v7zNUOCCCqapo5Hf0yRoW1OkOxBnV6sQvWZWSxHbrztEFiOwV0A7q3ng9qLwxvbI1LP3EU6kpqXXdh8ITAyMUGjAXH57Dk4O5F1HnFd7BoZQaZYQjwSSYZaQxPBcx3sGxlB//AIpFuXBvYA+ASAQVTOVN8MYBVYZaMQ5iYQjA8jnBhBODkCMhqMc6DSJOYKAP8IYCuI7macX8Ad77hnuqKYRaljGSY2XAlRzJxIeOvsg06o7nLmp55LF6KY1W1P/5oZ4WIafd+/g0qEu8ViBd0yJW6s94PajSH1zB3cyQ4rU385y7kJY5DQGBjaTwbgvBppXlaKlDHHtLA5Ywi1NjuGhkkKASlEDwEQjEEpjWf29QNkKtZ6xdKe6nv5twAOAPhDHK/hC1HFNU7mhMFXzHEvDidH71O5ic+KSGLRMd3pjEEWM5hYfxmCVC94UDze5RK1DyurCJwx4EFhXlrnYbwDyR33UnTgSaHqLyQDAF+yy5PFCrqlFm4CMFqPlaUjSUSGdojUtrugoql51YVNCIFcsawPjI3yw00sIhz3PiOOg6FMRo9ns9x3HRBRHIB/0Ho/tAmofP5VAF50kp9xCoAtAD58UqHkfGoubGPAHQ9jD/z83bqc72fC+aNj3n8ph1L7UuQXnQqZHz/etWvOQWfVcWBEYCqYjvU6N/VcOOBBUbc99WtWjWCs91KPAPi1XZ4sVtAttTAB4Bt1mrEwjsfanvwVk4VxZZz5E+PkRBPI7t+ps+OjcMSzr48hEwEgjyVDjhDYOzpmADDBOAiIM6DdEMGVEp48IpQlC+CnAM46zk94JYCnAaw7mUUIxsEcnw5utE7oVSkXkDjlPFMc3hcO3/FdeF1LPk7GPLetLhkwIkxsvArk+GA6PNblppyyxhhDoBSGMhnDGSOqiHoZZNS8EXUihIkOJHY9aOJ7H+cq1jGdTe7X7NJksYJuqYcv1rmCVSthbRHJ7feTirfPGyudOx7yu54AAZxJ56AqwRji2pjnNKYRnCNfLuuBiUrEf6g1lFJxxliystYTXPeIyPYfA5isWmJLjvr6d6KGRhwiEqeJx34dhpMjhp2seAkRRCTOEqvP4gM//rxSuQkj/Ohrq5uLwxUYTm4EuWVnYWLd8+Dkxo5lpU/ZQmcAXClp5/BILlMsasdxwVQQMq00zZPgOBIOeBjo9id+CZDhJOou0VCALfVqsYJuqZNHnrOgT3ml5jDSYW1P3spEMavI8Vp/NBiHLhcpv+PxI94dxhiU1gi0Bj9KhHzHwXA2Z8ZyOQ4hUA4DBEpFBOfxg4rWlUoBnB+sv04Anql+/HuHXerVAP5nqj9VJtIo7d9OAz/6XEDGBHwK42/KRZZYc6YpZydo8FffNG7HIoDMtc/x1BgD4gLZleeDuKiUmT2SKddxJwCe49B4Po+9o2Pkez5EUOBcB9NxS88t6zzegcTO+018z2MijE/LOv82gH67LFmsoFvqpb4AHKqUg431bxaprXdTZSFr7QJgwosgGB1QhX1bjnhxWCXorRwoVRTHsND3T4wDWgtHCAShQjkMwRk7FAluDi3whz47UP3neQA+ySOxNYzzr045iIoMnEQ7jd73M50b2BHTxYwn/JPXeTFBCW66r8QBc+DmL/FwfFCJSAIA3gjgY4db6aKURbljKcJ4B/ihGvOHqCkojgHEGJM7h4cREBkZFiMsLDs0D6LdSUhwddA61xx8WgUUv2KXI4sVdMt0+A6ArfVatOCSpTf/koliRlGLn6ULP4bSgV28PDzAxWHn54IxhEqjFIbEDxMhwTmKQaD3T0yyg5FvZAzlS2VwzuJHmKlH6Dkyh33te8pDex7ljh8hMzVBF9Ekigd2qtH7flJx848Pl9gUGuaQ0eCuF3WTbW5xdJAP3/k9ctM9VC07+5cAXnZo4QhLCBJdCNr6IEq5oy9VU9oagRBxHWTzeX4gm9dxChlX88BCP9w63/2IUNOzzh8EcJtdjixW0C3T5X/rX9AqVnpy2z0UTi8YaLZXZ3AvisK+LUoD7HCBZIwBZFyldeRwl7vvOBjOZMxoNsuk41T/HrFCuQzO+Iny+VKHLGFA7vv+pyOZp+8Lva4lIKNPOuZOqgtjD/4SxbFBAQDF/TtkxTKcwtgzLhgXDAAGb/06K48d0CJyaO/xaVRLujKtEPoJ5E95HpKRCKJupVorHf77UUnZc6VAzHOR8H0kIj4E54d5JQ5tfgiA2DM2QQ4pYka1fIEZEg64CnR68y0MIE7Ts85vtMuQxQq6pRHcCKBc1ycZBwnJ2jffwkQpo0yrnqUzDiKN4oFdEoB4jtgQsUIQ6MP7kAvOMTAxQTCGHy702WIBYPB9x4EnHUhR7YX97GcXHfwf0vcRlst8541/w6BDLaKJk+STe1DZUT1yzw8P2vysPLTHwGg1JYuXiMgYEgDyB3aJ0Xt+SF665+BxyXIAf35wsxFlhP1OG+7vP4AD4+OI+z7inucxxtIR10UyEoErhcmXA71ndKywbXDQbNq7jzLFojkqsv/QTmDv2LjI5gsll1GJWtlCJ0KY6ERi5wMmsethPk3rfAw2ut1iBd3SIPag3lKTRAjj7Yjte0K0bbmDprmwzZ6eCwmVnVCl/m3B8e40WyqVqCpNgnMUjnK3A4BwHIxMZrB3eCRZKJcxkc+hUC4daoVaJX2YvsJ1XUxue1Ts+/6njdexiI5ruRLBbevG5Oa7TXb749yRAgxAcf92Hk4OM36ySHfGYVRQgFGHGq8P3f5tFkwOae4dcij8MYBeIgM/lsD4Y7fjoX2D+PmmJ3DL5icxnMkmI67TMTiZwf07dqpfPvGk/sWmTbj1yafE7ZufZPc/s1VrY4w8KtL74IyYDJQYGB/TUSlaOuCCpAOuyrp98y1okHU+bpchy8mwtdwtU+UGVMqK1mXdGsdl7U/czCbXPU8ZNyJ52FptnLl0oPITMhgfFMfZBbNSEMYOloB1pcTg5KQez+eZOMwalUJAa40Hnt5yhpQSRFQR7WebspwCYPWRX84hALb3B58VqdOep5MbLpSlwd1gR4sEY2BSmvEHbwYBgkkHQmmUh/ex8ugBHVm0Spjw+I4W7rgIM6NcF3OcccCRDrJ7tvDxh2/T3Ve8QZT27wQYSwC4ngv5T6qQRXFfJSBfSAe7BwcxODn5hvZEPDo4MQkdhgIAg5SQnAsF0IYlS2hxOu1kS8d//rvHJrCWCcNatVsfGYTxDqS2/KYRZ+dADdkNFmuhWyxT4Q4At9RrpatoGpEDW0T6yVtJxdqp1SLeuRdFeXhfMZwYCvixDGTOkSuXgmIQhIJzOEJgOJuFUUqIwwLliAicc2ii84pBgFIYItRHnIuvPdb4Sd8HAXz3N/4JppRXIhJ/jkiIaBLFvc+YicfvqDiricBdB0GpyIv7tkBETxx8LrwYgtF+L9TkcOke3DDwkXt+yExQ1ofFDbxGxtPI7dqMzJYHIBkgGLvE9f0doVKfGhiudN91PY+5ngdXCCil4Pu+On3ZUhZqfZRUMzAGAwCCAfuH9ovR0SG4XmuWDSbpQQRF1fnYTxphnX8LwJN2+bFYQbc0ms/W/UnGYNwYS2/6BXcn9xvtx9FK/dK56yOcHJZKKcGP0eKUc458OeClMGSOEFBam+Fslh3vHROcb3SEON8RAuLI9KwXHHtPVClAk9mxSey/+SvktS+iI8aPCE4ijckn7zal7ISQnnfIOwKA53c/VQknP5EQgag0uDc8+LxABIcDk5vu4pmn7zNOqrPyt4w5z0m0b8g+fT+UUuCu928A7gLRSiEEXM87+p4AY+j0JUuQikZlMQgOBfRXQv+Ja0M+AAjXg9LGm9zyoCcj8dZ7Q6qR7aln7qLYvk2yAYGg1jq3WEG3NIX/A/BU/VZ6CpHhHSK9+VajomnTUh5VAsLJEUmAPFZJUs45ykHAJotF7TsO8uUyjecLwImrgr3qGP/u0uO/rQIcYAM//hzP796snFT3s2LBOYwK9OQTd1ZN3iM/mt/+KFO5CX2out3R+y0uYEp5nd/5+BFrAnM8aICPPfhL4q5vQJX0veL+HWcN3/EdMOBXAP70RDcZBAFS8bha19fDC+XyEQ1sqr+eEdHhP4zntjwAXcpTq3VeM64PWZxU7Zt+xoxw2DR//8MAfmmXHYsVdEuz+MJ0RFFF00g/cTOLDO3QKtrWMgFyRIbKI/15AOZYJcY5Y4AxPFMs8YjrYqJQMNlikckTC/qbABwuZCsBXHKiTZHjewgKebH/FzdCROOHfouIxFHs36azWx5kAkc6PyQD8ruf5MX+rSSjyWNeWkTiKA3uNoVdT0IcY5EYf+RWXhrcrbkXhZNMozy2/yX5gR3fk4JdPpXBW9fXi5jni0CpIzcS1Z96uPNAAMjt3ITS4G4t/Ray0skgjHdS21O/NtH+J4WKtVvr3GIF3TKnuRGVxi11Kbr243An98v2TT8j48VMq+QaMwamsmOyokHH/c18Ip83howezxcArQU/8f2tAPCGw/7/i046glQRvOFf38SzTz+gnbaKlS7jaeS2P0al7IQQRx0JcMdFqBTPbXuERCz5XJEhgkykkdv2KEr5jBRH1paHdBwURwb45Oa7yG3vBZOeGb37B79FwKuYcE74ewOlEI1G1fLOTlYMgue0l+Wco6yUKYfKHLRmhSNRyozz3I7HjYi3Src+gvYTcCcP6PZNP+fGi7FpNpc5gHrrP1isoFssU2QE0ylyQQQV70D6ydtEtH+zDlshjY0xkDYwQdHHiVZpzjGWz/NCOaBsqTjVm3rXYf/72ql8QPo+lCExdPu3IbxoZVNExmS3PcIB8Oe4eSsiyiafvh+mXFTsKK8BEwKkQj3+6G2VpuRH539XrsfHH72deZ2L9PBvvqP7f/k1JgU7efEXrWlpezvaolFRPso6ByrpfaUgLBeDoMwO/u5qMF5uy4PEwKglKsYRoKJt1P7ELxAZ3i5UNIVpxoh8AUDOLjcWK+iWZvO56XzYOBGIUlZ0PvJDgHE9zfrWzddzLmDCMkz5xKl2UkrkSiU2OJkJA63FFEudXQbg7FoEnYggAIze/xOe3/WEcdt7EYwP6fy2R477hRJA9ql7RX7P0yTjbUdssJxUJzJbHjQTj/1ayONcQAAo9j8jRu78ntr7f58SDODiJEWCDBHAmFmcTjNTTed7znUZQzkMvbJS3uGBdAxguZ2PsmB80HDHneNiXukuGBncptof/wVTkbbpZtwVp/uOWaygWyxT5WlMp1EEGYSJTqSeuVMkt99LQaJ7TjduYVzAlAtKFTLhiRSaV7quyT1jI6YYBApTb5P5LgBvw5Hn6SdEeC6CQl6MPvBz43cvR2lgG0oD29nxkuS55yEoFcXk43dAxtqOSBsUftyM3PMjprTh3PWO+31qcoRv/a8/cYPhPdz1fdBJPCtKayRjMdMRj7FyGB57oyEEJosFRUod4Y4XHCj2b+eFgW1GxJJz3IPDYbyo6Xj8p3Ayg0L7iela5zcC2GeXGYsVdMtM8dnpfJiECwC88+Hvgwd5bZzIHH5LOExYVqaUP2n5Wy4Edg+PRnLFkivFlF+vdwD4eI0qAgZg7L6fMZUb06XBPQgNMS5PvCcYfeAXLMiMaub4la5s6R5ktz6sh+/4NhMn+T6jApRH+xkX8qRiDgDQGm3RKEU9Tyitj+dtoNFsngE4Ir2fOy6UIV7Y/RRxdw439aluTuN7HlXpp34lwkRXIzanN9jlxWIF3TKT3IvppNRUF8LYvk2iffMvTZjonLvFZggA4wz85AothUC+XGZlpRifesCfjxo7lAGA4zjIDeyQE4/fGYaTQ5X3+QTnzY4UyO7aLCY33UluuhtgHMKPmv0//xJUGArpn1g4GWMQjltT05RExNecHdsDLYVArlw2w7nsMdL7Kuf++R2PsWP0W587U0O4ABnd+fAPGA+KvAEdBX8C4BG7vFisoFtaykoHY9BenHU88iPmjfcrHUm1cDe2QyYnOOeMzUT0fmV/wQZv/Sryuzfrk31jNQedjdz9fZBWxu9dgYnHb1dDd/2AS4apWd01kvD9CD/OYFS60WXNZD7PnWMcTzCAFfq3mWByJORzsakPGYTJTqS23qmT2++TYaKzEdb5J+2yYrGCbpkNvgfgnumIn4qk4I/tlZ2P/IC0n5ibaWwMFbWbakPyGfQcuK6LsQdvdicfv9NzPO+k4y05MPrQrTy38wnjJDv0npv+lREghNcct7Y4QWEVBtCe0RHAGHEszRcAysN7RDg+yOee251gvBhkfiLsfPB7zAjJaPrBnbcCuNkuKxYr6JbZ4tPT0sqq6719080yvvsR06AzyIZb3YxzzoSce+H4nANGcyLNprIZEq4PAsTQr27Czq/8rc7sfEK6rtMU6/wE+xBEXRejuZzeNTzCmDx2jygmOHSxiPLIPjXnBJ2AMNZO7Y//DLH9Tzsq1pD0y/+yy4nFCrplNvk66i0HW8U4EfCwyLse/A6BtCY5t9yrpDW4H3VFLOXPuQMBIjAhKo1UpiAoRATX8zBy5/fknm//h+s4Dmtm2qA5xm/ijMGVkjbv6ycVhsI9zj6JSQcaoPLwXuJuZE6NuYq3Izq4VXc8+mMextKNuOqTqJRWtlisoFtmlelF5ZJBkOhGYueDsv2JWyhIdoHNISudjILwohCt2CzkmErJwDiD4BxMiKbGLeRKpTIdZv4TgHQ0iq2Dg2rrwAAXjsNO8vVOmBn3iQymWXmtcfOBCxjhmq4HvkNOflRoryGNhv7TLiMWK+iWucBnAOyc3kzk0G6UdT74XeaN9Ss1lwLkiMCEhPDjRQDU8k+LCIyLpos5AGSKxUNWuuQcHbEY9o6NqTuf3gJwLuQUcvWDsYGiCYqa8Tkg6GQQJruR2nqnSW25Q4aJhmw+t2E6PRIsFivolgYSYppn6SCCjrbBH9sruh76Hik/buZUpy0icpLtuiLoZJ/4VBACw5msKCulu1NJOFKYR/fsVT9/7HEeKiU9153S2X04OaooDGe/BCwRjBeHLEyo7vu/DTDOqvUUpssnAWg7YSxW0C1zhf8BMDht6yfRhfQTN4vkjvv1nKogxzjzOpfEAHCr51PDlRKFcpk/unsPPb5nb/jTxzbpe7ds4UTEPc9jUw3EM0ExRqRnPyCRMYSxNHU+8kOK7t8iw3hD0tQGMZ3eCBaLFXRLE8gA+Px0L2IcH4w0777vm0yEBWW8GOaERcwAEU/riiVlFX3Kou44/On+fnnH5ifF8MSE43ged6SsLaqeiINm+QD92UJIuuPRH/Ew3t6oK3+m+u5YLFbQLXOKTwMYn/bCGe9CfO/jsvPhH5gw1m7mgn6SUpDRRCgBZbT1jtaClJI5rsdd1z3U/7xWy3h25ZxAjg9mtO65+2sQ5bwwbrQRG81xTLc4k8ViBd3SJIYBfKoR1nAYa0fnQ98Xsf7NukEVuKZF2Ri0u4IlHHA1h0uRzkUYY9OrF0Rmdp0iBASJLmp/7KcmufMBESQbdhT0KVTaEVssVtAtc5L/wnRdiETQXgyilBXd936DAaQrNbJna1UnKDB0ZA9Qh2TGetxnekcgAjDMzi6KDMJEByKDW1XXA9/lKppiDQrOy8AWkrFYQbfMcQbRgJxaRgZBsgepbfeKjsd+aoJkN82akDIBFpRUfGKv056ICwDWRJ9BZCJdZsIxM5/GSCDpA0zo3rv/F05+VCg/2ahUv89jukGkFosVdMsM8AkAY9OfnRwqmmTdD3yHRwa3KRXvmBXXu5EunNwoxMge1tbeDQhBhqyZPlP4Pctjwo8KmulnT0CY7KKOx35iklvvkUGyp1EFjwqwTVgsVtAtLcIYgP+e/oJKUH4SMjsqeu/6XxAX1bKwMyumxvHhZgY1TQyytlSaJSMRo5SyT7npgkoAoN2uJZpxwWbUQq9GtUeGtqnue2/i2k+wBtZFuAHAPvuALVbQLa3CvwOYmO5FGBkEqW6ktv5Gdjz+Uz0brnfjeMYb3cMoP8Fj0TjvSsQJNjCu+ZoaBhBS6MjSDUoXsjNqmhsnAgC69zdfhiyMCxVpmKu9jIoHy2Kxgm5pGYYbtnBxAeWnWNd93xSRoe06jHfMXK13xsBVCH90DwgMnDHW15bmAIx1ujeXkIBOyUy3NLw8w0tVmOikzod/YJLb722kqx2oRLbvtk/XYgXd0mp8DsD0TSsiqEgSTm5U9N7xRYBzbWYo6p24hChOam9sH8jxUAxDLE6nWTIWM2EY2ifcXMzyqCPax/cwxcSM7OAOBmPG9j2heu79hgij6Ua62kuwZ+cWK+iWFmWwUQtYxfXeg9SO+2TnQ983QaJrRhZ47UXhTh6AO3lAaDeKUGsko75Y0dUJGGukN81C1hqO55llvX2c79/KRVAganYtdyIoPwER5NWiX98Arspce7FGNrD5PIC99ularKBbWpV/AbC/MeYTh4qk0HPfTTy+7wndYFfosVZ4GMeHP7yLZGGckZBgAMqhwqrubua6ng5t1bgmmMkMpBTWdHdRR0e3oKGdcHIjVKlF0MSnLQRUJEU9d38Nsf7NTpDsbuT8KgD4D/twLVbQLa1MBpV61Q2zoFhYEn2/voGJckE3MC/4mBsIZoyODG0HI8MP1h8thSE6Ewm+tKNdk1JzpEv3/CEIQ8RjMbVxyRJWZBLO5CD3h3cb7UWbt4cggyDVh/STt6rOR35YrQbX0K/4BIA99ularKBbWp2Po0GuRlbtRx3tf1L23vlloyNJQ0KiGefpRrhwciPGH9nFtBs78r8RsVXdXRyMaW1z0huL1lje2RF2xuO8ECqIsMQjw9uIuGyKO4aRQZDoQmR4Z9h3xxeYcSKswemRk2hAsSWLxQq6ZS5QQMX13hgICJPd6Hj0x7J9089MkOptSiqb9uPwR3fDG+8Xxo0c8d/y5TIWpdNicXu7UUEAxqyd3rhViaN/bNwZz+cp4jgw0kNkcBuXxYyubN4aCBGUFwczRi+67XNwcqMyjLY1uoDRJwAM2QdrsYJumS/cAGB7oxSdpAvtx1nf7f/DYv2bVZDqbfB5OoGEQ9GBp0mUc/xoITGGIDnn6xcvqtiUNi+9YbiOg4lsVmzau9d4rkPaT8Af3sW80d2kvXhj9VxIqFiaeu+6USd2PSgbP48wjkoXQovFCrpl3hAA+GjjVmIDFUmBByWx+JZPM1mcDMNYumGLMQkHMj9uovs2c+P4zzmnZwzIlctY3tkhlnZ1Wiu9wTAp2ZYDB9jgxKT2I1HIwoSM9T/JjONTw2ImiBCkeqh9089158Pfd4Nk9zTbwh2Tf4HtqGaxgm6Zh3wZwOaGLfrV8/TI4Da55JefJBKOaVSakfKTiAzvoMjwDq79Y1uFxhgQgZ+9YgXjUqqyFfWG4UgJHSqxfXDQOEKQkQ5i+zYxUcqaRrjdGRkEbb2I9T+pFv3qBqbdGEh6jQ6w7IfNO7dYQbfMY/62oVcjgyDVi9SW37h9t3+RwmjakHSmvTCTdCm2bxNEKcuJO8cWBcaQK5fRnUzKS9atJRijg1BZUW+Q9QzO2d6xcZ4pFg2LpRE98AyLDG0zOpKa/kYw3gknM6yW/vw/BA9LQkWTzWj88++oxI9YLFbQLfOSbwP4VWNnMUeQ6kHnw99jXQ99LwxSfQZcoN4oZSM9ONkRHd/zGGkvdsLrMADZUgnr+/rk+evWKNLKlMtlwIp6Q6z0bL7AhiYzxvMjEMWMiO9+FMbxqN5ny6pHNQCppTd/wnhje3mQ7AZrfAzEVmudW6ygWxYC/9poa46kBxVJ8r7b/9tJP3WbLqcXEerJECeCirUh1v8ERYa2S+0nTr4BIEK+XGZnLVvmvmDjRu04jg7KZWupT5PK+JEYymQIABk/jvjuR5gzOairzVNqfLYG2ovBuFFa8stPssSOB90mBMEd5J8A2KpDFivolnnPzwD8X2NF3UB7cZDj8SW/+IRIbL/PlFN9tbveOQczWie33QsYzTCFcqMMgDIGmWKJrevtca4771x0pVJBOQjsk24A48UChUqRiSQQGd4hErsfMSqWru3ZUqWDWhhtM323/7dJP/FLEaT7gOaUBXoYwBftk7NYQbcsFP6l0RdkZBBG2wCj+bKf/Sti+58KgvTiqS/8RAhjaUQHnjSJ3Q8LFUtjqq5dBoCIMFksoj0WEx3xOGvFWu+MMZAxUErNjWMDzlEsB7IUhuBcAIyz1Na7OA8KmoQz5edKjocw0Wl67v6a6nzw/3iQ7AZN41jmJHzYvt4WK+iWhcR9AP6n4YJkDMJEJ3i5KJb/8KM8cuCZctC2aGqizhhIOKZtyx2QxQwn6db8/Y4QGM3lwv0TEwZCtJzPPVAKnalkuSMRV0GpNOuizoVAIQjK+XJQkpxDxdKI73mMJ3Y/YsJ4+8mfKxGM9BDEu0zPvV8Pe++60VHxdkbSbVbJ4J8B+Il9vS1W0C0LjaacMzKjESY7IQuTcsUP/lZED2wJgvRJRJ0IKpZGdP8WnXrmbh7W6tKtIhhDKQxlMQwdzlrv9SKlEHFc9+rTT+epeFzPtqhzxhBq7SmjPc5Yxao2irc99Wswo3XFyp6CZX7v18PeO77kqlg7M06kefX/gb+yr7XFCrplIbIdTXC9H7TUg2Q3ZH5CLv/hR3l0/9NhuX3xwZX+GB/g0I5v0ptvhcyPPqfU65RfKM5RDEMTat2age5CYDiTCVwh1MvPOVskotFZF3UiEkprAcYqG694O5Lb7xOJnQ+aMNF1zHQzRgbG9REku03Pfd8Ie3/zJVfF0sy40Wakpx3kc6icn1ssVtAtC9ZKH2yKqJNBkOqGLEzKlf/3YZ7c8YAup5cATBxhoTEyCJJdiO993LQ9/Wuh4p11W3CcMQRKlcgY1YpR7oJzFIKADU5mWCoSwbVnn8USsYqoN+p+GCqZAVNuPUsEpc2h8DUSDkCadzz6YzATKnNUW1VGBspPQEXbqO/2/9G9d3zZmQExH4U9O7dYQbcscDIAPtasizNjECQ6wVQglv/oYzy9+Ze61L7EGDdSWdyrqUyMSHff9y3wsMjNNPtus4oLoCVbsDHGoLV2imEgcuUyEp7HX3zmmYj6vi43SNQ1EXzH0THXLQdTzAQ44muJECY6kdj9iGx/7GcUtC2ig/8eRAgSXTCOp5f88tO6595vyDDezpss5kClrPGwfZ0tVtAtC51PAniiaSJFBmG8HcQYW/qLj/O+O7+sjOPrcvsSBG2LECY6dc9dN6rErgfl8Vy4U8UQwRHCZ5w71IJtVRljgDE6VyoVJefIFItIRXxxzRmnw5GOKjcgv14bAwaEz1t/StCbTteXs884dCTBeu/5Gk89c2dY6lqBINWLcvsS8iYGwhU/+HvqeOzHMkj2MHK8Zov5I6h0VLNYZhVph8AyR/h7AN9spqWuIimIoMh67vpfN7rvCT1x6pUlFW0zqS13um1P/8oN4x04eE47HUH3HVc6gkOZFhT06j9DbcBYReAniyV0J5PiBaeuD259/AkdKiWkEPVbEYwhXw4o6XnOi844nX/z3vtUqVyWnufheJug5wwlEZQfh8xPiKW/+Dj3R3aF5Y5lQfTAFrdt8y3CzY7wctuiaT/PKfIX9vW1WEG3WJ7lWwDeCeCaZlrqxvUROH2I9z8pYv2bGXGHuA5FGG0DhJy2JUdEcKQIBRc61OGUfffaGHDG6rZ+tTFgjEEw1hBfPzvsOgzARKGA1T3d7uSaVcGD27Yz4pxPx1LnnCFTKqEvnWYXr12DX216QmtjBD/WNRmDI/hz7osZAxVLQ5TzrPeur0gjXS7CEldenJUPVoBrvph/HcDN9vW1zAWsy90y16z05kKV4+0wloaOprnxYiKMtwOcN8Qtq42BJyVinsdoCkFfjDGESiHqOEXfdcumBgFijIGIEJTLRMYQEcE0ScAIQLZYwlnLl8vl3d0qDAKa9nk6Y5gsFLC6u1us7Ok5bgtaxpiRQppjiTMzGsbxEcbamXFjIkh0MuNGmlXO9Vj8k31tLVbQLZbncieAL8zUlxFjIN7YV0Abg4jrOgnf55jCIbo2BpJz2rB4EUnO+VQFmTEGpTXCIKAlXV3quvPPo9OWLFZhEDREyYjoiKKoDIDSGoHW/JJT1vF4NKqmGyTHqHJEYYxhG5YsAoRQ6qhNkCGC5LwkOSudcGwOPcsZzSz4CYBN9rW1WEG3WI7NRwGUWvkGGGNI+P5UzHOoIMCanp5wSUeHnykWnam+kEpr6DA0p69YYa4943TZk0zydb29iPieCZSaliUOgKTgz9mOMMZQLJcRc1158do1AJgO6/guQwQpeOU7AOSDAD3JlFjS3m50GB75d6sbpIjrutqYufaobWtUixV0i+UE7ALwj61+E6lYVIKxEyqQ1gbgXG1cspiXw5BrradcwEWHoTlt2VJz6do1ohAEbCibRSoaFSs6uwy0rtvvTpU+5CLiuu6xLGLGGDLFIlZ2dcnTly/VRqmav4uMgScdz5XSNcbAEEFwzpd2tBOOrhxoDHzH4b7jiDko6NcA6LOvrMUKusVyfD6JFs7pVVqjLRIh13NJneAcXYcBlnZ0mL50Wk4UCgUQqZPJOQMQlMvoSKX0eatWsVy5jEApcMagjGErujo5E0LraZylM85ZxHWPm3ZHAApBwM5Yvkyk4jFVc9oZEVwphec4QlOlYEw5DNGbSgnf9+mIgjNEiHpeWQoxF3MGUgC+bF9XixV0i+X4TKASPdyShFojGYnwpB8x5jiCXhVLvaqnG4JzBEqZqURkV4XanL18GaQQohyGh8S0GAToSaV4X1sb6Tpbtxpj4EoZ+FKGxzuzPijAEccV561axQBoVYv1TARXirzg/NC+I9AaCd9n7fG4piPd+JSKRDxHcDFH8/qvAfAAgLR9bS1W0C2WY9Pfqj9cV93E7fEYHS8wLgwV0smkXtzWxotBgFBpBuCklq4KAizu7NRLOzpE7qigtGpRG76iq7Pyf+sRdK0R9z0n7vvyRKVZGWPIlkpY2dUlVvb2aH2cCPXjkfB9R3LODm5iqGq1t8djDIA5tOlhTKeikXCOp/SfB2A3gEvsa2uxgm6xPJcLWvz3s+5EguN4mdBkaHE6baKeJ5XWUwrOrl5Hr+ruguCHmbeHWc7FMERfuo3HotG6AtZAhKQfCT0pYU5idRsiKKPZ6UuWcimlriEYT8c9nwnOOR1xPYN0NAowRkQETQTXdZGKRJxwGoF+M0QCwF0A3mJfXYsVdIvlWd4P4LWtfAOBUuhMJJjv+/pYqVjgXPe1pXgtgV5hGCIVj5tF6TQvBMEx9wCBUmiLRvnidBug6+pMa9rjMS7EkWJ7zB0LgEI5QE9bUqzt6zWk1Elz06v3TnHfN0ffu9IGCT/CpJTGEMEohVQkQolIhNTcC4g7Hv8L4P/ZV9hiBd1iqZTR/GSr30SgNZLRCO9KJOioM2EopZCOx6kzkeClMJx66rQxWNSeRtz3+ImC7YjAlrS3A4zpWs6dDREgBHXEYqT11AU0UJqd0tfHpOue1Eo3xsBzXUpFI89x6WtjEPVcxHyftNYAEbXH4ybiOFK3jqADwL9iJookWSxW0C1zmA9jHqSsVUSV4ArJe1KpQ2fCh6kadSUSFHHdKQvVwfPk3lQKR9V8eQ6lIEBXMslTsRjV4qpWSiEVjVA6HhO15LIXgwCdyYRY2dVp6GSCrjWSvo+Y69FzLHRjEHVdGfc8DmMAMNOVSDBqzSnwVwD+zr7SFivoloXI3wD42/l0Q4FS6G1LQTquOcplTJ2J+CHnNMPJS46HWiMWiZj2WIyVjyq+8hxhNgZx3+O9bW0EU0M4mTHUnUxS3PNFrS5urQ1b1dUFCKFOuEkhonQsRr77XKubiCA4o5jvhQAQ8T3qSiZ4MPfPz4/HX8P2SLdYQbcsMD5S/TOvKCuFznhc9LYljamKsDYG0nV1Kho9dC5MBEghGHCCJupaoz0eQ8L32VTElgisty0FMGam4navegBMX1tbXQZxNWVO9ralSJ94w2E6DtvMPGdB4pynIhEfALoSCUpFozysLxZgrvC3AN5jX3GLFXTLQuCPq9b5vKNS4lTwxek0UK2Apo1BzPNY0vflQXc4geAIbsAYncBUN+lY3EghppSPXQ5DdMXjLBaJmKkIYqgU4tGo6UmlKuf6ddyrJyVfnE4Tjj5iOMxz4LgudcTiCI+bnw9EPa8MoNzTluKSc96KfeWP4r8AvMK+6hYr6Jb5zBsA/Md8vbmDBVgWp9Ms4vsm0BqonBMHjpTaHMrBBhwhfDAm6XjWM+csHY1IM0VXuDIGiUiEdSYSNKVod2NocTpNqUhE1GsRl5VCXyrFpOMcs9CMUQrtsbhJx6LHdaOHWsF3HM9zXdaTTKKswvkyHb4F4FT7ylusoFvmI5cCuGm+32RZKaRjMdmXThOUAogQ9/2II8Sh0qpEBM9xJOOcHc/6FUIEUddTUy3pWjmP5qIrEcfxLObDrw/O9bKOdqaNqbtdWVC5V96RSJA5lpVPRJ3JOHmOI45XhU7rSve5jUuXmGQkIsqhmi9TwavOd2lffYsVdMt8YjGA7y2UmyWALe/oAMAUALhSMMH5ofNyAuBwQbxaUOW5IqcR9z0Z86tFaKaI0hrpWJxDSDpR61EVBOhta6O+tjZRrLNk7MGNgSsl70wkCEeFA1S9DLo7mWQn8jJUI935+r4+z7S+q/1oTgfw3/b1t1hBt8wnvg2ga6HcbDEIsCjdJtqTCQJgBOPFw/WOiMA5KwnOi8fUMEOIOK72HYfVVIhGayQjPiV8Tx9vI1D9OrOmp5tcKbmevoiy9liUg7EjvjBUCqlo1HQlErx0kqh1zjkMEZuHgg4A1wN4q10CLFbQLfOBzwK4eCHdcNXqFMs7OxgAxTlTh2uVNgaeI4XvOMKQOabsRj1PCc5rkjhVCcCTyUjkuFXjwiBAOpEwyzs7ZSEog03zXkOt0RaNwnNdHLGJMAY9qRSL+744mZeBiDBPxfwg/wnbdtViBd3S4rwdwLsX2k0zACWlsKKriwGgUhh6h5dI1cYg4rhuxHU9HKdCW9z3opLX1nGseo5OqWjEnOAvmXV9vRT1PB6q6aeHhVoj5nk86rnmoGv9YA36xek2Bkx7zzAfSGMeB4NarKBb5j8bAdywUG++HIboSMR5X0c7zxVLzpH2NyA4N64QxeNkoitPOqWaeo5XEZzzZCQiUU2bO5ygXEY6Edere3p4vtae5ifYREghKOp55mC/tzAMkYzFTHcyyepJiZunvBHAdXYYLFbQLa3IlwC4C3kAQqXZ+r5FXHJeLgbBs41MiMAZQ8z3nvOZg81MIq5j6qlnrivu/hBC6MPd2Aet5lMXL6ao64pGdTOr5qPLuOf7z57QG/Sl2ygeiXDV2kViGo2t926xgm5pOf4RwPkLfRAOBsf1tKXMZLFoeFXQCYAUgid838MxosOFEE7UdaP1CHqoNRKRSMR3HPfg5xljCMtl9KTbaE1vr2yUdX4QxhhcKUMA5tmUuA5mppESN0/ZCOAP7TBYrKBbWoXLUemgtuChqgW7tKMj6gp5RC62IYOo65bBWHj4OXn1HNy4UlI9FdOICA4XWgoRHPx8xUpm+szlyyE5b7jVTBWPQxmAUZVGMXVXoFsAfAhAmx0GixV0SyvMr0/ZYaharqhEnksh4EiBwwU6VBqJSMRzXdfR5nChJzhCFAXnZUIdgg6Ac6akEAEq9dqhw5DWLurTyzo6RK5Uaqh1foxbxvKODkQcR7RYC9SZogvA79phsFhBt8x1/gHAaXYYjlQ4YwyOtrY1EaKuqyOuUz4ida1SrIVJIZipI5OLiCA5Z64UHKgEwkU8X5+1YjkPlGLNkNjq/oADYJ7nqaWdHTYY7sT8EYC4HQaLFXTLXOVcWFf7lNHGIOK6MhWJOkfkjFeCzCKO4HVXTqOKrhMMAUTmnFUrqC0akcUgaFIOGYMyJgKAL+/oMO2xmCgrZR/y8ekD8E47DBYr6Ja5yj/bIajdkk5GfIUjy8jBlZI5XKCeM3TGGJQxCLVmAGF5d7de39cnssXmuNoZY1Bam1ypaACYld1d3BDZYLiT8zt2CCxW0C1zkesBXGWHoWZLGu2xmARjR0i34Byc8/oEHYAxxs0UCr6QUl24ZjXTxvBmnWdzxhAoZfZPTIbtqSQtSqdFYRr14RcQGwG81A6DxQq6ZS4RAfAROwy1o7RGKho1rutq/azbnThjRaqzKbgjJUayWWWUUpeeso6lopGGp6nhqM1HvlwWQRjKU/r6SHDO5nkZ10byFjsEFivolrnEnwFYYYehdqo54yIZiZA57BydMabrPewmIgRah+uXLtFrurtFptjUqHY4QuDA5GQ5FY2WVnV3VzYP9tFOlVcAWGKHwWIF3TIXWATg/9lhqI9KTXeHdcRjwGFWredIxuqUxUIQYFlHR+SCVav8QhDMSNOTQClnTW+PF3Ec2MpwNREF8Eo7DBYr6Ja5wP8DkLDDMA0YWEc8DgD6oJedM0b1X67yj7JSzBA13VouBAF6UimxqqvLaXKO+3zF1ne3WEG3zDq9AN5lh2F6hEqjPR7njucdqt0+XauaiEAzdI5tjEFbNAopBGwhmbq4DMAyOwwWK+iW2eSPrXU+fQKl0BaJsPZolEwld5t50omwFmk7yhgDEUEbY63z+pAAXmiHwWIF3TJbdGMB9jlvioVLBM91eHcqCQAExuAILlopsszGtE+bF9khsFhBt8wW7wSQtMPQIFE3xLqTSQ7ODYhgs74WHJeiEiBnsVhBt8w419shaBxlFaIzkWCpWMxK+cJkMWwPBIsVdMss8GoA6+wwNA6lDeKex7sSCRtVtnB5gR0CixV0y0zzdjsETYH1pdsAQJM9lV6InG+HwGIF3TKTrIatP90USmGInmSScylNYDuVLUTOtkNgsYJumUleC0DYYWg8odZIRiKiry1FlV7iNgVsgbEWwHo7DBYr6JaZwpapbC5sUTrNJeeGbKj7QmS1HQKLFXTLTHAagIvtMDSPYhBgUTotlrS3oxyGdkAWHufaIbDUgrRDYKmTl9khaC5Ka0Rdl8U8j4VK2cprCw+bPWKxgm6ZEV5ih6C5MMYO1UO3Yr4gWWGHwFIL1uVuqYdlqFSzslgszWMtAN8Og8UKuqWZPN/OHYul6bQDSNthsFhBtzQTGwxnsTQfCWCJHQZLLRPGYqnHQp9XGGNAB8+rOQfndq9rmRN02SGwWEG3NIulqJzttTTlUgn5bAbFfAFGa7iRCDzfV0SEcrEog3IZQkpEolHEk0l4vg+bCz57m61iPo+gXIbWGlopmGq/dS4EpJSQjoNILAbHcebb7XfbGWCxgm5pFqcDiLTaj2aMoVQsYmx4GFpr9C5erM+88CKsXr8h7F682E22tfF0R0fJGMPHR0ZkLpMxgwMDwbbNTzg7n9mCPTu2C8/30dHdA8dxYIztm9Ks50REKObzmBgbg9GaovE461myJGjv7BLxREKkuzrLnucFhohnJyYj46OjPDMxXh7ct88ZGhjgjDGkOzoQjccBoNU3YnE7KyxW0C3NomVqTB9M9ZoYHcX4yAh6lizR17z61bj4iivN6RdcgO6+PgHAwbN1VQ9fPFn1v+FAf795+M47ze0//Sl74M7f8HKxyHsWL4bn+1bYG/WsOEdQKmF0cBBhGNKy1avNBZdfThvPOVev2bBBLFuzBql0mg5bt1j1DweAMAypf+dO2rJpU/jovffiobvu5Lu2bhWJVArtXV2HNgotSMrODsuU3yPrRpxfvOHSS5r9FV8F8Oa5LuSMMYyPjmB8ZAQbzjpbX/va15kXvupVrKO7m6O+YFACYLZufsJ854tfZL/8/vd5GAS8b8kSCCmtsNcJ5xylYhGD/f2IJ5Pm4iuvNC+49lpcePkViCeTDPX1CtC5TIZu/+lP6Uff+Dp75J57ZFt7O9q7u0HGtJqw/yOADzbr4t+86247Ca2gWxawoN+NORzlzoVAIZvFgf5+rNmwQb/x995NL37ta5njuhyN63Bidmx5Wn/p4x/HrT/4gYzE46y7txdEZM/ZaxDyMAyxf88exJIJ86JXv0a/9h3vZMvXrKl3w3W8TZi+5Qffx5c/8Qn2zBNPiMXLlsGPxWC0bpWh+iyA37eCbrGCbgW90UQB7AHQMRetcgAY2L0brueZt7zv/fpN7/l97noNFfLnWIIP3HGH/tTf/g1/6rHH5JLly1tNLGbjQYFzjuH9+1HI5+jFr3mdedef/RktWrasXmt8SgTlsr7xE5+gr3z6U1xKyXuXLAVRS1jrnwbwfivoliltlO0QWGqgE5ViF3POKi8Vi9jx9NN0zqWXqhtvuVVf/0d/JFzPFWhu31Fx/gte4H7xFzfTu//yg+Ho8BAN9veDC9tR9nhWuVYKO55+Gr1LluhPffu76sOf+hRbtGyZRJPb8LqeJ37nAx/g//OTn+qVp5yitz/1JFQY2vREixV0y4JlOeZYY24hBEYHBzEyOGj+8O/+LvzETd9ki1escGZybkspnXf+6Z+KG378E71kxQqz4+mnYbS2YnHUc8pMTGDfzp30+ne9K/zSL26mcy+9VM7wGsRPOeMM54Yf/wRvfu97w327dmFybAxibm/A7O7QYgXd0hR655plvnfnTjiuS5/+9nfMm3//vWIWF0C+/owz5Rd/fjO95vrr1a6tWymbycx1sZgZRZISgwMDKORy+u8+93n9px/7R+G4rpytzaGUUvzh3/6d+KcvfSkIgrIZ2LNnLj+nnF12LFbQLc1gTtSVPhjFvuuZZ7B240b1pV/crM66+OKmu22nJBaOFH/+L//K/vazn9O5zCSG9++HkAs3O1RIif5duxCNxcxnf/BDfc1114k5su7wy1/yUnnDj35CvUuW6N3btoFzPhe72mXtsmOxgm5pBm1zQcyJCLueeQYXXn65/vwPf4TuRYvmmmKKl7z+9fKz3/t+EI3H1d7t2xekpS6EwN7t29G7dKn53A9/aNafcYaDuXVkw1etXy+++ItfmHOf97xwx9NPg4jmmqhbC91iBd3SFGY1IO6gmO/csgVXvfKV+hM3fZPNpuv2ZGw462znf376M1q+di3t3r5tQZ2pCyGwb9cuLFuz1nz2e9+nxctXzNnnFI3FnU9+69u4+rrr9BwUdSvoFivolqaQmAtifvV11+l/+O//YS0wf1lXX5/z+R/+iM684EKza+szC0LUhZQY2LMHPYsXmf+86SbT3tXVCu4J56M3/Dde/LrX0a6tW+eSqE/YZcdiBd3SDGY1wXr3tm246pWvbBUxP0QskeD//rWv48wLL9I7n5nfoi6kxIF9+5BKp81/fO0bprO3t5UCCMTff+7zdM1115mdW7bMld80ZpcdixV0SzOYFZe7EAK7t23DxVdeqf7xC19syXkbiUb5J7/1bXbWRRfpPfP0TJ1zjvGREUgp9Me+8EW1dNWqVowG5H//+Rvoqle+srL5mv3nNGyXHYsVdEtTdGk2xHxgzx6s3Xia+vvP30Bo4bxc1/P4v37lf9nqUzeYvTt3zqvod8Y5ioU8JsfH8aGP/6fZeM45rXxz4u8//3lz9sUXh/t27pzNzVcA4IBddixW0C1NWbdn3OIbHYUXiZiPfPrTFE8mW14BE6kU/5cvf0V3dHeroYGBeWOpG6Wwf+8+es9f/qW67CUvmemCMQ1HSsf5+8/dwLp6e2lw9p5TFjYozmIF3dIkMjO3dWAIggDZiQn60499TK3esGGupTzVTe+SJfIjn/4Maa0pOznZ8mfqXAjs3r4dL3n9G/Rb3/8HbL48p66+XvlX//mf2mhtcpnMbATJ7QdQsMuOxQq6pRlMzKR1vnfHDlz39rfra6579XyrzMLOvvhi571/9Vdq+MABo5Rq2RsRQuDA3r1Yd9pp6s//+Z+BeVaq9JxLLuW/84EPqMGBgdlo5LLPLjkWK+iWZuHMlJgPDQzglNNPV+/50F/RfJ2nr33HO/nLf+u3zJ7t21uyoQtjDLlMBkJK8+f/8q8UicXmY/Uc/qZ3v0dc+bKXq1k4Tx+yS47FCrqlpS30IAigw5De88EPUTQWm891U8UfffSjWLtxox4eGGg51zsRYWj/flz/h3+kTj/vvGZ3tpvV5/S+D38YXX19emJsbCZd7wN2ybFYQbc0i6bXleZCYGD3blz7+tfrS174wvksEgCAWDwh3/+Rj5hQKSqXSgBrjdsV1ed08ZVXqre87318vq8li1esEG96z3vM6NDgTH7tLrvkWKygW5pFU4tcMMaQGR9H39Kl5vo/+uMFMz8vvPwK8aq3vkUN7NkNzub+LTPGkMtmEY3Hzfs/8jcEYCF0n2Gvf9fvsAsvvyI8sG/fTHlTdtslx2IF3dIsmhpxyxjDyOAgrnvb23XP4sULqZsJf+ef/D+sOmW9Hhsemosdv57znIYGBvC6d/2OXrV+/UJqJSff/N73EhfchGE4E983apccixV0S7MYaaZIjA0P45TTT1evfec7gXnuaj+aZDot3/jud+vMxATNQjT11J8T5xg+cADrzzxTv/X972ML7TldeNnl4nlXX2MO7N3bbCs9BxvlbrGCbmkik01dwTIZuu7tb6dINLoQG4izV7zpzfy8579ADQ0MgM3RADmjNQr5HL3lve8jz/MX4nMSr3rb28mLRExQLjfzew6gkodusVhBt7SOoDPGMD46irUbN+prX/f6BWf1HYZ83TveAUOG9BzMTa+kE/bj4iuuVC985SsX7EtwziWX8Oddc41u8sbLutstVtAtTWUYQFPMksmxMbrm1a82fiQiFvIAv+Daa/lFl19REYs5dpaulAKB0Rt+53eBhREId1wr/WVv/C3GhSDTvI2XDYizWEG3NJVS9U9DyWYmsXzt2oVunR8Si1e8+S2GiIzWes78KMY5Bvv7cfGVV+oLLr98wa8b57/gBTjroovU6HDTmqHttMuNxQq6pZlk0eDqVYxzjA8N4/nXvMikOzvtfARw6dVX8zMuuMCMDs2diHcVhpBSmle95a0t3fGukRuvy1/yUioVi816RiN2iC21Iu0QWGpkvKFCEQSIp1Lmype/DC0gFBqA2Lt3b7h3375SsVDwykHgSimN73mF3t5eZ82aNW41+nk6q7x80WteEz5yz900FzwWjDEM79+PCy67TF905ZWsAWPI+wcG9O5du0qFYtENw9D1XLcUj8XU6jVroh0dHQzAXC/5yy69+mr29c99VhfyeRGJRht9fetyt1hBtzSdiQYqBcaGh3HOpZfqU88+Z04u3mEYmjvvukvfduut/IEHH9Rbt25lBw4c4IV8/ugqdgKM8RUrVpjrr79ef+iDH5RSyrrv6YqXvox9+3/+R48MDspEKjWrY0BEUCqka1/3unrXDLNr1y7z45/8hN3+61/rxx5/HAP79/N8NssPG0MOQLSl06y7u9tceuml+i//4i/E2rVr5+wmr3vRIn7OJZeYn37rWyK6fHmjm7dYQbdYQbc0nYa6AoNyGc+7+moDwJ1D90g7d+3S//WZz+B/v/pVDB44cLC06eHiEmVCQHAOYww3xkRAhF07d+JvPvIR/oMf/IDu/M1vKBqN1mXRxpNJfslVL1Rf+dQnkWxrw2zmpk+MjuKU08/Qz3/xtTUL+fe+9z31qU9/mv/qttsOxke4R4wh5xBCQGvtkjGYGB/HxPi4eGbLFvGlL35Rfe/73w9e9cpXunP0XRDnP/8F6qff+hYZY1iDXe9jdqmx1Io9s7TUSsPquZcKBfQuWaIuuOzyuRIMR7v37FG/9aY3qVUrV+Lf/u3fxOCBAxKMCdfzmOt5OPyPIyU455BSwnVduJ4Hz/chHYc98vDD/Hd/7/c0Kq7jut7N57/4xUim03qGqpId24nCObKTk7js2pcYx3Gmai2bm775TbV23Trz6le/Wv7qttskACEdh3u+f+QYOg4453AcB0ePLwD51re8hfX398/Z/rJnXXwRW7x8uSoVGlpE8UD1j8ViBd3SVBpW7CI7OYl1p59Bi5Yvnwvz0HzsH/8xXLliBW76xjccxpg8JOLu1A1EIjpUQexrX/0qNj3xRN2h6hvPOYefetbZZmJ09lKSy8UiOnt69WXXXsumsl488OCD6tTTTtO/9cY38m1bt0op5SER55zX5GnwfB+5XE589Wtfm7OZD509vXz9mWeyzMREIy+7D5VKcRaLFXRLU2mMy50xFPN5bDzn7FkPfhoZGVEXXnSR/tAHPyiJSLqeB8ednpe3+nl+6y23TMe6FOdf9gIU8vlZiXY/WI73jAsvMCvWrTvpM/rABz6gLjj/fPbU5s2OqAo5F6Lu44Lq5/jmJ54IUAmmm4uIU04/XSsVNvIZ2Qh3S13YM3TLrFjoWilE43G9Yu26KVl+zeLhhx8Or7jiCmQyGUc6DsQ0BOgIMar+MxaLTefe2NkXXYy29nYdBoGQjjOjY0NE0FrTJVdddcJUtUwmo17+ilfgjttvl4wxuJ4HIpr2OFYFkhYtXiwxhzMglq9ZK6XjwhjTKFG3Ndwt1kK3zAgNKf+qwhDJtjZasXbtrFlet99+uz733HNZJpNx6nEJn0iIVBDAdV1z9TXXTEuI1p95Jlu9fr1psEt3ShTzefQtXarPe97zj6tSw8PD6pxzzzV33H67dKpxBI0aw3KpBAD66he+kObw+8CWr10bdPb0BNXf2whsURmLFXTLjNCQA12tFOLJpIwlk/5s3MSjjz4aXHPNNQaAdP3G/QTGGKpNO8yHP/IRrFi+fLqWJd947rmmmM/PrEoxhomxMZxxwQWme9GiY64T2WxWXXrppXr7tm2u47pgDdoQAYAxBgDwute/nq666ipnLr8QHd3dIp5Mcq0aFry41y4zFivolpkS9OJ0L1IqldDV21tua28PZvoGMpmMetWrXoUgCBzP94EGiRBjDEEQgIjoz//8z82HPvjBRriJ+dkXX8Idz5vRtqoVd7vCec973vHWCfPa176Wtm7d6rmeV3E1N/D3hUGA884/P7jpppsOz1Wfk3i+78YSCalUw5xNtsuaxQq6ZUYYQQOKy5AxEFIqAGaGfz/99m//Nu3evdtplHv4kAiFIcgY+ou//Evzz//8z7JRQrRu40b0Ll6sG5wadUKCchmdPb164znnHjOl8KMf/ai++eabpZCNDcM56OHYuHFj8Mubb+acsTlfZpYxBtf1YEzDBH2XXWYsVtAtM0ERDThHZ4zBGDPjlteXv/xl9X//93+Ccd7YQiCMwWhNb3rzm/U/fuxjDRWh9u5uvnrDBpPLZmdsnLITE1h5yilm2erVzxmkLVu2qA9/+MMMAJMNFPSD5+adnZ3qlltuYW1tbS0TtGuMAWvM/m0cwIBdZixW0C0zxbRbTB2erz1jIpXN6r/6q79iALjrug21zoNSCb19feo/P/GJphiB604/nc3kOXqpVMKpZ511rDWCPvI3f0NEJD3fb+gYqkorUvPv//7v6O3tdVrpheCCg9CQsegHULBLjMUKumWmmHYVK8d1MTk+7pcKBW+mfvRnPvMZ09/fL5wGi/lB3vXOd7LOzs5muIj5mg0bTDQWMweDxZqN4zi08Zxzn1Mj4KGHHlLfvOkmdnBT1ki0Ujj9jDPCt73tbS31MhitUSoUIERDHv0Ou7xYrKBbZpJpt1B1PQ/jw8PITEzMSNpaEATqc5/7HAPAGu0ZqJZmDa964Qs1mhTAtXTVaplqb0cYND+GsFQooLtvkV61fv3R90Jf/epXCYDw/OYkJ7zk2mvndM75McerWCzls9lQiIacEFh3u8UKumVGmXYlKyklspmMObBv34zU6f72t79Nu3fv5tJxGm5ZkjGIxmJ6xYoVTducLF21Si9duUrlZ+AcvVgsonfpEta3dOkRgk5E+mc/+xkAsGZF3CdTKYE5HtV+NPt27WLjo6OsWn9+uuyyy4vFCrplJpl2Lrp0HEyOjcntTz3F0fxId/rud78LALxZ5/aFfJ6Nj401U4icjp4eJwxnwkLPY+UppzwnqfrBhx7Cli1bmrpmFAsFA4Ba6F2gfTt3YHxkRE63XHCVZ+zyYrGCbplJBhtxEc/38fgD96PZgn7gwAF9y623Nk9pKwu5e/8DDzQzkMusWr++qMLmOzTCIETv4iXy6PXh17/6lQbAGyRcx+TmX/5yNlIZp/VcNj34YCMzJqzL3WIF3TKjDDXiIql0GpsefJDv37u3qQv4Iw8/bLKZjGBNss6rizn7whe+QE0UI97Z0+NSk4PijDHwoxHq6ut7zvqwc+dOBwBvVqMYxjnuv+8++aMf/ahlBL1ULNLjDzzAY4lEIy6XBbDHLi8WK+iWlrPQI7EY9u/ZI+++5RagiW7WBx96iAGA08TmJkJKPHD//eKTn/ykqvVeSqWSue2224q3/epXhSAIjvdZlu7s5JFYjLRuXhyh1grRWFz1LV16dOpU+PimTcVmTqpqm1r+oQ99CKivu5oBEAAIMUNu+4fuvNPsePJJkUylGnG5vbBV4ixW0C0zTA7AtH2/BCASjeJXP/lxM8/R9ZYtW0yz53q1wAr/wz/8Q/Hzn/98qmNjPn/DDeHSZctw1VVXiauuvFKsO+UU89hjjx1zLLr7+orxZDJUYdi0+yBDcBxHxJPJyNF7loGBAbeZY0hEcFwXmzZtkr/9279tapgT9M1vflO/+Npr1Zq1a8unbtwY/smf/qmemJhotqWvf/3TnzClFOONSVkbtEuLxQq6ZaaZQCOatBCho6cbj99/n7jtRz9sltlJz2zd2vSDZyJCNZVLXHvttfzGG28MTmQlDg4N6cuvuEK/+/d+T4wMD3PGucs593bv2iWuedGLaHhk5DnjkWhrY34kgmbmojPGYIg4gCPcGfl8nheLxaYXe2GcQ0jJvvzlL/O3v/3tJztPNz/+8Y/DtWvXmje+8Y38Fz//ubt927bEU08+Gf34f/yHOP+CC3Qmm22aO2PnM8+Ye269lXf29jYqc+Ipu7RYrKBbZposKiUqG7CACziOy755ww3MGNMM4ZXFYjE2E4NyuKhff/318qUve5m+//77D7p/CQBt3rw5fO/73qcWL1qE23/9a0dKyT3fh+M4kI4Dx/MwNDjIPvmf//kcIXNdNyKEdIiaJ+haa3i+j6NTsHK5HMqVLnLNHkRIKSEdR3zlK19xlq9YYW688cZwbGzskDDv3r1bff6GG9QZZ56pX/7yl4tt27YJLgQ7+Ls934d0HLZt61b5Z3/2ZxrNcb/rmz7/eYyPjgo/EmnUNXfbpcUyrcXODoGlThrSRpWMQVdfHx574H7nG5/7XPDm3/99QgPzkMMwRGEGS6YeFHWtFP/pT37Cf/qTn+iVq1ZRV2cnjU9MsO3btzOjtWSMHRLNw6276o3zX95yi/r7v/97dcQ7yqrlwpt4OmyOI+hCiBkr1UtEEEKAMcb27N4tr7/+epNMpWj5ihUIgwA7d+5EuVTiALiQElJKENGhcTysrDD77ne+w//tX/+VEolEQyP5HrrrTnPz/31X9C5e3EiPiQ2Is1gL3TIrZBp5sa6eXnztvz4jdjz9dMMPiGc6qZmIwIWA63ngQoidO3bw+++/X2x95hlORNL1PJws9Wv79u3B5OSkmumHKh0HuUwG+dyRBWyMMZipsrMHx5AxdtDa5pnJSbHpscfw9FNPoVwqSek43PN9CCFO6O4eHR2lp7dsCRv726D++1/+hRERb1AxmYM8bZcVixV0y2ww3KgLERESqRRymYz49w/+pUADA+Qcx6FEIqFna5CklHA979CfqUbaB0EQUUq5s/GbiYiO7jSSSqUQjUZn47eAc37EGLqeB875VM+tdblUaqSg689+7KP0yN13y76lSxu5yQnRoHRQixV0i6VWxht5Ma01Fi9fjgd+8xvxH3/1IY360paOhUomky3XvUprLYwx/Chx00RkwJpXkI4xBjJGB+XyEecUnuepSCRSbsF5yqWUjaoNT7f/7Kf6ps99Ti5asaLRJYR3wBaVsVhBt8wSY82wxpauWoVv3XCD/M4Xvwg0xlsuVq1c6bfa4AohFOf8CPOvXCwVVBiGvJmCzjnKpRLGR0aOFkFavny5brVxTCQSzooVKxry/Ldu3hx87E/+REQTCeY3uHUsgJ12SbFYQbfMFiONviARwXVddC9axD7x13/N76jkc0/Xp8nXrFkDtFY5UcTj8ZIfiRxRuH1seNgt5HNCyObFsgohkM/l5L5du44O3XZO27jRQ2vVWcfKlSvD3t7eaT/7/l27wr/47etlUC6L9q7OZsQT2IIyFivollkj04yLGmMQSyaRTKfYR37/PfzBO++cdtWvCy+80ACgYAZajzZQiLxYNHrEgfvA3r1eZnxCyiZWvGOMQSuFybHREo4qHrRu3bqw8ohaZm9EV111FcM027FOjI7oP3v7W8XQ/v2ib+lSaNUUR8Vmu6RYrKBb5pWgA5XUqbb2DkghxF//7u/ITQ89GExH1M8991zR0dlpQC1jXNKKFSvoKCHS48PDBRWGYE1OH4vGY9j+5FPPac5y8cUXSwDUzEp1jUIpBQDm2muvndZzGNo/EL7nVa9ie7fv4EtXrYJWTUs8sDnoFivollljopkX11qja9EiaK3FH7z2tfL+O+6oW9Q7OjrEC1/4wtZQ8sqmgy695JKj75Vvf+op1/U8NHtj4nk+BvbuoaBcPkK9zjrrLKxfv74lzHOjNTZs2GCuvvrqetc46t+1K3z3K1/J9+3a1WwxB6zL3WIF3TKL5Jr9BVopdPb0wPV98WdvfYtzy/e/X2/VL/aaV7+aAOi57i4OgwCMMX3ZZZcd/W6qfbt2UjNblx4kEo9jYM8ese3JzUdE3zHGxBVXXnnw/8zdTVH1H295y1uO9nJMmScffST83Ze/jI+PjIilq1ahmQ1xqu+S7YNusYJumTWyM/ElWmt0dHUhnkzyD/3e78qv/ddnQtTRGOa6664TK1eunNPu4oNtSa+86iqceuqpRwjRrmeewa6tW0WiMV29ToiUEtmJCfbEQw/TURso9oqXvYwB0OEcjkcIy2UkEgn9jne8o571Td/+s5+p97zylf+fvfeOk6M48/8/VdXdE3d3NmdJq5wDEkgCkQwSOThgHA77sLGx737nwDmdz/bZ5/P38Nnc2Xf23dk4GxswZzImgxGIIIFQAEkop9WuNk/uVFW/P2YWCxBoV9qdnVk979drCKvVTHf1VL/7qXrqKdPJZo3cnPmo1/fpxQjWdSBI6AQxXDLIbVVZEKmXx2Joam3BD//pG+Z3PvdZ7XvesO6yhmGIj3/84xr5uinFSH7eV370Ix95S9985aWXVH9PDxvNhLgjEYbBNq9bx/Cm1QEXXnQRnzFjhtRKgRVhlJ4/Jn399dfrhoaG4Ubn8nc//rH/1Y9/TETKylhdU1MhZA4Ae+l2QpDQibEknpd6QVBKIRAMYdLUaeze3/3OvP7yy3Bo375h3W0/ef31vLKqSuaHtYtORNL3MXv2bHXNNde8uV/K9c+u4ZwzxgpUT72iqgpbN7zMOw8efPMchbjmmmsAQBXbgxFjDI5tIxKJ+J/5zGcYhrEngGPb3jf/9m/Vf3z961ZtYyOrqKwc7WH2I9lFtxOChE6MaUCJkavmNiQGa6RPnjULO7dsMf561Ur+6N13eUM9jtqaGvGlL35RAVAFvFkPTSi5nczkv954I/Cmed/D7QfVpnXreKy6BoXK1A+GQug4cEC8+PTTwJvyFj79N3/Da2prles4RfVglL+m6mtf/7pubW0d6mJ9tW3jRvfaC1byh/7vDnPyzBmjvkXtUeik2wlBQifGEjsfpRcUrTVUvkysaVn8a5/8pPGvf3+DTieTPoaQMPeVr3xFLDrlFOl7XtHISGsNaK0/8tGPyssvu+zNItLPPvY4Og8eEKEC1lJnjMG0LDz3+GPAm4bdqyorjS9/6UtF9WDEGIPveTjllFPkV7785aEOtcvf/89/y+svv9Q4fLBdtM2YkSt9W/iRB9qUhSChE2NOeqw+eHBefcKUKeyeW35rXPOud7FnH3t0KKMG4qc/+QkA+I5tj73UGYPnupg9e7b/05/+VOCtw8TyyQfuZ4FgqKCi0VqjqrYW6597jm/duPEtH/yFL3zBWLZsWVE8GA0OtQPwf/GLXwylkIzes327/zfvvhL/8bWvmbHqGl7X3Aw1dg8nNOROkNCJMSc5lh+ulALnHG0zZiKdTIi//6u/Mv7p05/SnQcPvmO0vmTJEvOnN9+sAaixlrpr24hVVnr33nsvC1jWW0T07GOP6Q3PPSeqa2sLfmxWMIh4X5949K47Fd5aOpf/+je/YYFAQI5lGx4hc/nr3/xGLViw4J2G2rVj2/7N//Zdee2qleLV9evFlFmzEAqHx1LmGsBhupUQJHTipI3Q3yB2KVFVW4vWtjb22D33GB9deT7/xb//u8yk028r9k9cd535rW99S46l1F3HQSwW855dswZTpkw5mojkfbf+noExxoUo+PFppVBdX4enH3pIdB069BbjTZ82zbjn3nsxVm14hMzV92+6CR+55pp3WqQvH7v7bu+vV61kP7vp+0ZlTTVrmjgRWmuMcXLfbtDGLAQJnSgCEsVyIEopMM4xYepUBINB/r//7zvGR897F/vjL3/hO7Z9VLF/4xvfEDd+97sKwKAYCiIhpRRcx0Fzc7O/du1azJo162hr0fSf//Qn+cwjj4j65uYxk060rBwH9uwRD95xB44SpeOCVavEA3/60+ujHVrrgol9UOY33XST/vsbbni7Jx75/JNPen/73vfqr37iOrOv67CYPH0GAsHQWEblR3IYJbZxEEFCJ8YnyWI7ICUlQpEIpsyahXQyKf7tS18yP37hhezWn/yvjPf3yTfdPPmXv/Ql44933ukLw/Bdx4GUctSExBiD4zjwPU+fc845/vbt28W0adOOurBcay1v+8n/ctOy2GjurjaUB6Wq2lrcd+vveXdHx1ENePFFF4kNGzbohsZGz3NduI4zapXkGGNQUsJ1HHDO/dtuu03dcHSZyzWPPep97gNX44YPfdDc+vJ6o23GDFZZUwulFIpoyd1rdBshSOhEMZAuxoPSWkMphfLKSrTNnIne7i7xH//4j8bHLryQ/fjb31Z7tm9/Q/Lce979bmPfnj3svPPP96TvK8e24Y1kRTnG4HleLqLU2v/nb39bPvnkkzwcDr+d9fRvf/QjvPzcc0ZdUxP0GJerraiqwsE9e8Rv/vOHeLtocsGCBWLXzp38E5/8pKe1lq5tw3WcEYvYGWPwfR+ObcP3fb1s+XJv586duPrqq4982lGZVMq//9bf+5++8gp88ZprjI0vvCBaJ09GXVMTMPbD60djK91GiBG71WitqRXGEVefcXohP+6fAXy96L/kjIExhlQige7OTkTLytWSM1eosy68CKevXIlYVdVgZrR+avVq9dnPflZv3LCBDz7wciEghBi2mKSUR1YaU2eedZa8+eab2Yzp04+Wzf66zNetXi2/9NGPGOWVlQiFw0UhIen7ONzejn/8wQ+8C993lXiHYEBv27ZNfuMb38Add9zB8r/Hjrcdfd8/cmhcTZ02TX3/+9/HFZdfPihyDUBtefll/eT992H1gw+xvTt3iPJYBapqasE4R5Hf4z4M4Pdj9eG3r3mWbpokdIKEDgD4AoDvldQXnnN4roveri64to2miRPVgqVL1alnnaWWn/suXlFVJQDo7bt365u+/339f3fcgb6eHn6EgIdqIw1Ah0IhdfEll+Bzn/scW3HGGQzHGBXbtnGj96WPfoTZ2axRU1+PYlnnzTlHYmAATjYrb/zVr/wlK860jtEW+uDBg+qWW27Rf3rwQbz44ovIZjKD7agxtNFBDUBFy8r0RRdfjBtuuIEtO+20wc/U2zdv1s8/+STWrX4KWzduEJlUmlXl6v6/PlJTAswHsJmETpDQibEW+scA/Lx0v/0MdjqN/t5e+J6nG1pa5ZTZs7DsrLPYBVe+W0erq7Xn+3LL9u3s+eef1/v27TO6OjuNRDyObCajuru7nYGBAR2PxyGEgNYa1dXVbOLEicFp06Z5py9fzs4//3wWi8WGMgkuH7/3Hv2dz39eCEOw2obGQtURHzJCCPR1d8OxbfXl733fv/B97+MAhnJuurunx3/ppZfE5k2b3N179rD+/v5Af3+/7u3tzQLQLB+2K61RUVFhTZ482Zg7b557/qpVYu6MGTI/goKt61+STz38CHvlxXV8+yubeWIgzspjMZRXVsIwDJTY/SwDYCKAHhI6QUInxlrolwK4r+Q7Qb46mJPNIj7QDzuTRSgcVk0TJ+pFS09TS5Yt51NmzPSbp0wxmGUNziEb+Rvy4PD5kdGnMcRIXgNQr23apH/zX//FnrjvXlFdW4vywtYRH7bUk/E4eru69HmXX+F/7PM3sLaZM94wtD5MBp9aFHJ5DRqABUBDg3fv2yOff/pp/sLTT2P75s2sq6ODu47DImVlqKishGGaKOF72HoAi8fyAEjoJHSChD7ImQBWj7tOwRiklLCzWaSTSdiZLKygpYKhEG9sneDV1tezqtpao2369GxNXb1VUVkpahrqncrqWskFD+rcNioIBIPSCgTcQdFLKc10MmlkM2m3fe9evW3jRmP9mmf1S8+u4dL3eUNLC4QQKPY92xnnUFKi88ABBEIhtXjFCrX4jBV8+ry5Xn1TMwLBYMAKBADG4GazcF0Xvufavu/7yXicu66rTdOEaRgwDJMB4P29vcH+7i7Z1dHh796+PdBx4IDbvnevmYjH4To2C4ZCiJZXIBgKgRf/vPhQuQPA+0noxEhhUBMQJ8DAeDwprTU45whHIghHIoM/40opdHd0mAf27Ib0fXiOG/J9H1YggEg0KoLhMGOMIRQOwwoEEYpEdLQsqqSUTAihbdvWAz29yKRTYqCvT6cTCREpL0d1Xd3rw8XFLnMgV3CGMYbmSZPgOg5f+9RT/M8PPIDyWEyUVVSwQDCIcCQKAMhm0rCzWWitDaW1cG07VzNgMDGOMUBrZNNp7WSzwrBMYVoWrEDACkfLUNfY+JYkunEUhFBBGYKEThQNPcitRS8b7yfKGIMQApGyMkTKyt4iOCmlIaWE1hqJeBxK9kH6vuH7vjE4pC+EgBkIQAghYlVVqKmre73aTSlKSikFwzRR29AAAPA9z5BSIpVIIN7XBw1AGAZErsqdAeR2cTtalnu0vBycn3SraF+mWwhBQieKhW4AvSeD0N9R9pzD4ByGaQ4v0h1vNxPTHHYbnOQcpCYgRhIqLEOcCD6AfmoGghg2fQBeoWYgSOhEMdFOTUAQw+YwxmkOCkFCJ0qX/dQEBDFsNlMTECR0otg4QE1AEMNmJzUBQUInio1OagKCGDbbqQkIEjpRbOylJiCIYfMqNQFBQieKDZpDJ4jhkQFwiJqBIKETxUY/KFuXIIbDayR0goROFKvQqUAGQQwd6i8ECZ0oWmgtOkEMnfXUBAQJnShW+qgJCGLI7KUmIEjoRLGyj5qAIIbMFmoCgoROFCu0Fp0ghkYGwA5qBoKETpDQCaK02QPa0IggoRNFTJqagCCGBBWUIUjoRFHTS01AEEOCCjERJHSiqElSExDEkHiJmoAgoRPFLnSPmoEgjgntTkiQ0Imipo+idII4Jv0AtlEzECR0opjJAHCoGQjiHTkEyjchSOhEkSNBS3EI4ljQHujEqGJQExAjBAm9gGgASikoreH7Cr6U0Bpg7G1+X+f+LTiDYQgIzsEYg+CMGrNw0HA7QUInSoIBaoLRxfMlXF/C9yUYgw5Zlm+ZhllZZnmRYMA1hAhblsE4Y+CcacG4cqUUnAGuJ+H50nM930ll7Ijt+nB9X6YyngEAwuCwhIBpCDBGkh8l9lITECR0goR+ksEAaGg4rg/b9SE4Q1kkJOurynVNLKpjZWEei4b9cNAygpbFgwFTCM6OlDFjgNBHvKfSmnmeNLKux1zP89NZxx9IZXkynfX64mkjns7qZDorHE+Cc8ZCAROGEHQxRo4N1AQECZ0oBWjIfUREzuB6HjKOCyG4ri6PyhkTY2iqiaG+qlyXR0MsaJkGY4x5vh9SSkMqJTzPFy50biw+j84/GLz+hAAYnHEjEjRRFgoYdZXlhimEVkqbtufpVMZGfzIju/qTsrM3Lrr7kzyRzjIALGiZsEy6XZwAPoCOkX7T29c8Sy1LkNCJEYeWrZ0gGduF43moLIvIeS11elJTDZpqYqiIhgVjjDmeB9fzkUj7Q35P/ab/kFpBKiCXx/i66hnnDGWRIKoropgxoYE7nq/7EinV2RvX7d0DaO/q533JNOecs0jQgiH46/PyxJDYAlqDTpDQiRKBluMMNxpnDFprpLI2lIJurK5Q0ybUq8nNtaymIso5Yzzjekiks6N+LErlhvcd14fW4IIzVJZH0FBdgXlTWlRfMq0OHO6X+zp6cLCrj/enbR4MmAhZJsjrQ4JkTpDQiZJhgJpgqCIHlAJSmSyk0npCQ7WcO7kZk1tqWVk4YGQdjyUz9tgen9awHQ+24wEALw+H+JKZ5Zg/tUV29AyonQe71K6DXegeSBmWKRAOBsABkvvb8xo1AUFCJ0qFODXB0KLyVNaB7/t6YkO1nDulRU+f0MADliHSWQd9iTQYii/L3HY92K4HxphorIlhQkO1XjR9otx58LC3dW8Hb+/q54YQLBoOgDHQcPxbeYWagCChE6VCFzXBO4vccX2kbEc3VperxTMm6hmTGlnANI1UxkbGdsAYK0qZH4nWGumsAwAsaBnGabPb9KxJTWrXwS75yu52HOjqE4JzFg0F8pn6RJ591AQECZ0oFWhP9KOKPDe8PpDKIBQw5VkLp6tF01t5eSRkJNJZZG03J/ISXPvteD5s12emKcTC6a2YMbFBvra/03/5tf3sUHe/EQpYCAUtaArXMwA2U28gSOhEqZCgJngjnDFkHBdZx9MzJtTL0+dPQ3NtzEhnHdYbT5WsyN/8wOL7En2JNEzDEAuntYqpLXXy1d2H/A079rPu/qQoCwdhmcbJLPbDALqpRxAkdKJUSOZfZSd9VI7cUHN/KoNwwFKrls6Ri6ZPEBrg40XkbxU7gy9zYrdMQyydO1lPm1Av12/d627addAYSGV4eSQEfnLOr79KtweChE6UEvH866QWOmMMrucjmbExtaXOe9eSWaivLjfjqWy+ZCsb9+fv+RJ98RQLBy1j5dI5avrEBvXc5l1654HDIhiwED75huFp/pwgoRMlRRYneXEZns9gl0rpsxdNl0vnTmGcwegdGJ9R+bHEnrE9ZB2PN9XE+LvPWSw37zzgPf/KLt6XSImKaBiC85NF7BShEyR0ouQ4qYXel0yjIhryV502R0+f0GAmMzZczz9pNzsZPO1EOgvDEGLJrEl8YkO1v2bTTrVlT7tpmQbCwcDJIPWtdGsgSOhEqZE6GaUllUY8mcGEhmrvotPns5pY1OhLpPPbmdLOZYwxSKnQG0+x8kjIvPyshaqtucZf/fJ23pdI81g0DM7H7dy6D6oSR5DQiRLkpCr/OjhfnEhnMX9qq1y1dA4zBDP6Xk98oy/Em9srlbUhXM7nT23lTTUxuXr9dm/bvg4jFLRY0DLHY7S+K/8iiFGHUxMQI8hJUy2OMQbb9ZDK2GrFgmneJWfM54A2EmmbovJjtJtSGn3xFMojIXHlOYv4eafO8pXSKp7KjseHoE666gRF6AQJvVifghlD2nbhS6kvXDbXXzJrkpHI2Oxkni8/rmg9Y8M0hFg2dwpvqqn0H1n7quroGTBiZeMqYY4KyhAUoRMlyeGTQeYp24FSWl96xgK1ZHab0Z/KcNeTJPPjkLovFXrjadZUGzM/sPI0LJzW6sVTWZ2vGz8eTpOWrBEkdKIkGdflXzljSOR2QVPvPmeRmjulWfQlUlxKTfPlJyT2XGlcwblxyRkLxMpTZ3ueJ1UyY4OXfsPS/DlRMGjInRhJesa1zNNZBAOmf+mKhZjcXGv0JdKvC4k48fbN2A483+fL5k42q2NR7+HnXuH9yYwRKwuVcgb8Frq6BEXoRCnSP15lE09nEQpY/nvPXaImN9ca/Qnai2bkI/X8EHwizSY315pXrzxNN9fGZG88Da1LchQkMZ4fcgkSOkEReonK3PTf967Fqrk2ZvXFSeaj/mSYSLOKspB51XmnYU5bk9ufzGjfV6U2r/4aTrKlnAQJnRg/HAYgx5PME+kswsFcZN5YE7P6EhkaYi9QtJ5fxiauOGsRXzZ3skyks6VWeY8KyhAkdKJkSWOcbKOaS4DLImCZ8j3nLFZNtTGrL5EmmRf4GmRsB1nXNc4/dbY4Z/EsmXFcZTteqSTL7aCrSJDQiVIlDqBjPIgklXUguFCXn7VQt9RVmv2JDC1LG6NI3XF9JDMOW7FwGr9w2VzP8TyZtt1SkPomuoIECZ0oZQ6VukAytgsA6vIzF6q2xlqjL5Eml4/xNfF8HwPJNFs0faJ1xZmLfK21SttOsUu9g64eQUInSpmSTYxjjMF2PLi+ry9aPk9Nn1Av+pOUAFcs10YqjYFUms2Z0mxdfuZCT2vIVLZopZ4AsJGuHEFCJ0qZkqyMxRiD6/mwXU+tWjrHnTe1RfQnM0zT9Syea4Tcjmy98RSbMbHRuuLMhb6GVkUq9Q4AfXTVCBI6UcqUZGUsKRWSGVuvWDDNXzJzktmfTDOlNWikvTjpS6TY9IkN5hVnLvIAqLTtFluOw8t0lQgSOlHqHCzFg+5PpnHKzIlyxYJpRjxjcykVybzopZ7mMyc1WpetWOD5UqqsU1RSp5KvBAmdKHn2lNLBMsYwkMxg5sQGb9Vps1nWdblHu6aVVKQ+c1KjdeGyeZ7r+copnk1dnqOrQ5DQiVJnJ4D2kvjyM4Z4MoP6qnJ50ekLIBVE1vFI5iWE0sBAMsMWTm81z108S6VtF54vi6FeAEXoBAmdKHl8APtLITJPZR2Egpa8ZMV8hAKmmcqOi929TioYAKk04uksXzZvsjhj/lSZSGe1lGOazvgKgG10dQgSOjEeKOqEIMYA1/PhK6UvWDZXNVTHeDyVIZmXqtQZ4PsSybTNzl40A4umT/AGUpmxPKTNdFUIEjoxXijqeXSlNFJZR585f5qcNanRHEimGQ2zl7rUX192KFYuncMnN9fK/uSYVfej+XOChE6MG9YU842/P5nB7LYmuXz+FJbM2FCKLth4kXrGcQHAuGzFAlZXWeYnxmbk5Vm6GgQJnRgv7ESurntxfdnzu6fVV5X75586C64vRW73Lrpg4+aGxhiSGRuRUIBfesYCGQxYMpV1ChmptyM3h04QJHRiXNCNIit7yRiD7XowOFerls5BJBQw0oW90RMFlPpAMoPG2lhg1dI50velKuCD2/MAHLoKBAmdGE88U0wHo5RC2nawYuE0v62plsdTWUqCG8cM1heY3dZkrFg4zUtlbShVkMz3J6n1CRI6Md5YW1w39yxmTWryFs+axOOpDNej9DmGELBMA4YQNJQ/rMYDhOAwDQHBR6bhlNZIpm2+fN5UY3ZbkxtPFSRJjhLiiDHDoCYgRonVANIAImMt83TWQWV5WJ5zykwupRa5wiMndmPX+X+GLQvl4RAs04BSCsmsI13f94IB0ywLBQXnuaH+eDoLx6OiNUe2X9AyUREOIWgaUFojbTvK9Xw/FA6ZIctkGkDW9ZBIZ+H6w6/exwC4vg9TCnH+qbN1d39S9iczojwSgtajEq1vA7Ceri5BQifGG/15qV80lgfhSwVfSn3OKTNkVUXE6ounTkiqgyKoLo8iGgriYHeffHLTNr3tYKfsGogHehNplXZcLxIwRXVZVDRWx5x5k1rE/LYWXl9ZwbsG4sg6Hjg/OcWulEZFJITKsgg6++Ly6Ve26y37D8mueCIQT2eQtl0/FglZZaGgbK2tlnMmNos5E5rQUFUhugeSyDjusNpusIBQZVnYWLV0rvd/T7zIHNfjAcvAKDj9Cer2BAmdGK88PpZCZ4whnkpj0YwJ/uy2JiN+guuSpVKIRcKoLo9i4+4D/v1rN+inNm9n3X39DICV/zUz/xoMRE0AenJzo7xs6QJ55fJTRFU0wg/1Dbx+jCeFyLWGZRhoqq3A/u4+9evH1sjHN27Foa4eAUDkf40DCB/x3wxgevqEJnXhkrnq8qWLRGtFFT/UOwCl1JDbjjOGeCqLtqYa84wFU70nXtzKTEOMRu2Bx6nLE2MJG6WhJ2KMuPqM04vpcOZjjLLdc5GZjfJwyP/AytN0wDLNjH18We2DfaS1tgp9ybS6+aHV8s5n1jElpQDAmDBgGOKou7NpDfi+D60kAKgJDXXyH66+hC2bOcU40N0HX8pxL/XBB6FYNKxvf2qt/+P7H+eZTJbn2k7AMIy3tB0DILWG70sg33aNtdXqc1euwqpT5ojueJIlM1lwPrQ0IA3AFBzhYMC/+6n1etu+TrOqPDKSQ+8DAKYB6Clk296+hpa8EyR0EnrheAnAKQWPCJVGMmvry89c6M9uazL6E8dXDU5rDUMItNZW4ZlXd3j/cuu9ONzbb4IxWJY1rAcMqRR81wUYk1/5wGX6vWcsFh19cTaepS6VQlVZBKYh5D//7l756IubDADcDATAMZiLMIS2kxK+5wGAfM9ZS9UN714llNK8K56AGKrUtUY0HEQybfu3PfoCsx1PhEOBkZL63QDeXej2JaETR0JZ7sRo89BYROfxdBZz2pr92ZOaeCKVPW6Zm4aB1toqfdtTa72/+9Gv+eHeftMMBIYl88H34owhEAwCWosbb72X3fHMi35rbdW4lbnSGuXhEExhqC//4g756IubTGEYPBAMgg1R5q+3HecIBINgQog7V79gfPKHv5ID6YyeUFs95OVojDGkMjaqYxHjrEUztONLLUeuTOCD1NUJEjox3rmvsDIHso6LimhILp83BZ4vxfHetDnnaK2txK8fW+N997Z7OQBh5WV0vGitc1IHxL/ddh//8+bXvJaaSshxWH/WEBxVZVH9g7sfVs9ufs0UpskMwzjuiFhrDcs0YVgW27L3gPnx//iFeq2905tYPzypx1NZzJvSzOdObpYjtJRNA3iEujpBQifGO8+jgPPoWgNZx9Onzpqk6irLjOMt+6mURktNJe5fu8n/wR8fFABEProegWP8i9RvuuMB9CTSqjwcGnfReWNVDA+u2+T/cfVaBiGYwfkJD28PjnRYgQC6+wfE9T/4JTbtOei11lYNWepSKjiez1csmIbq8qg/AhUDHwOwl7o6QUInKEofseg8V8d7Qn2VXDC1lScz9nHdp5XWqKssx/b2w/Lbt9yFQZmPZL6J1hpWIICD3X3GHU+/oKrLoxhP+SwB00Aik1W/feyZXPuZJkb67KxgEBnbNj/337dgT2e3bKqJDWmkY7A2QVVFRJw+f6pyPf9Eh94fpi5OkNCJk4U7CvEh+ZuyPnVOGyzLFK7nH58oDAOcMf3Dux7RjusZIy3zv5gl98/7ntug9x3ukZFgYNxc8NqKMjy16TW1/WAHF6Y1Ou2nNaxgEIlMxvzKL+9AKmPLymgEagiflRt6z7A5k5v57LYmP5HKHm+UrlHgaSWCIKETY8kmjPKWqiy/k9r0CfVyWks9T6azx71EraGyAo+8tFm+sHUH44Y5epGzBgzLQvdAnD+7ZaeqKouOi4vNGIMvlV7z6nYFQAgxireZ/EjHnkOH2Q/uekSWhYJDznqXUkEqZSyfNwXRcMC3Xe948iMeAbCdujhBQidOJu4czTf3fB9By5KLZ07SWmt+vEOopiGQcVx115qXNABhGmJ0O2DuoUO8uH2Pdn1fjYcNY0KWiUO9/f6W/Ydel+6oIwR/4IWXxeMbt/j1sfIhP3ikMg4aqiuMJbPadCbrHs+R3ktdmyChEycb/wfAHq2IMJlxMKutQbXWV4lkxj7uJKeqsihe3LFHbdq9n7ETyMgeLrs6ukRPPMkss/SLN0aCAew73Ms6e/s5NwpzPgHTBADx4NqNWiqlh/pgxBiQzNhs4fRW1lpfKVPD++44AO6hrk2Q0ImTjf0YpbW6jushGg7IhVMnwPX8E9pJzRBcv7BtpwIgTCEK0zKMo2Mg4R3o7rPDAavkL7QhBA709EsAfKiV3E6UwQevHYe6WEffgApa5pD/ruv5CFqWcersNiittZRDHt15CEA7dW2ChE6cjNw68tE5kLFdzJnUrBprKkTGdo97nbjgHMmMzbYd6BQACjb2LQwB33WNeCZrWEbpR+iG4DjcP+ADKPgUQsb1ZNpxfWMYD2OMMSTTWUyf0MCmT2jwE+khR+l/oC5NkNCJk5V7ARwYyTd0PYloOChntTVq15Mn9H0OBSx09MedAz19biEbheWeHQxfKnM8XGTGGDypIhiDzZ8qwqFAeTgY8PzhrXCQSkFrLU6d1YZQ0JTesVdI9IKy2wkSOnES42AEl7AxBqRtB9Na61RjTYWRtp0Tej9TCCQyWTGQyprgouCNk7Ltkr/AjDH4voTtemPy+SHLRDgQgD/MpMjBGgat9ZVi9qQmlTj2XPo9AJLUpQkSOnEyc/tIvZHvK4QsU85ua9JSaT5C+WtGoSPLvDdUfzKdKfW67oIzZFxX9qXS7lh8fjBgZUwh5FCrxh2JBuB4Pl84vZXFysLyGA8lt1NXJkjoxMnOWozAmnTGgFTWQVtTrWyqqRS58p0jIFYNaBS2YtugxHsSKSY4QynXi+OcI+u4snsgMSYhekt1pQha5nHtIsmQy8eoryrns9ua1Dtst/sqqHY7QUInCAAjkEyklAbnTM2Y2AAhmFAjVGOdc+YKzh0Uvgwrj6ezIV8qlPJadME5so5nJbJ2eAw+Xk6oq2JBy+Qn8n2wXY/PndyMimhYOkeP0u+gLkyQ0AniLzfE1Im8QcZ20VwbUxMaqnkq64xISnrW8dBYVcFbayo5dOF3P2vv7c/2p9JewZbLjQLhgIVDff1OTzzpFzIPwfV9AEzPaG7AieZSZBwPdZXlxuy2JpW23aON/NxGXZggoRNEjg4Ad53IG/hSYWprvY4ELeH7IyNfx/NQF6sQ05rqx6RRDg8kzETGHvXqdKNJ0DTR3jsglO9zs5BFcqREW1Odmt7SwJPZE0suZLkonc1pa0JlWVg67hsy3h8A8Bp1YYKEThB/4XfH+xc9X6KiLCTbGmuQdb0RyyPTADhjbNmsqQyAVAUcdmeGgXgiiQPdfX6pbtKSby2989BhCYAXeOJAnzqtjdVWlBnOcW7KcyRZx0V9VbmY1lqXi9L/8ke/pq5LkNAJ4o08DGDL8fzFtO1gYn21ro2VcdsZ2dyrvmQKK+ZOZ1Oa65XvuihU1nl+mJ3vPHQYpVpcxuAcKdvWOw52chSwMI/r+QDj8uz5M2F7/oh9sC8Vn9xSh6BlqvwyuP0A7qauS5DQCeKt3DLsMExrCM71pMYaDQYx0jF01vVQUx4V7z3jVABQvizoXDrferBDu76nSzEtLhoKYF9Xr9zWfrhgPmeMAUri9NlT1SlTJxp9ydSIvXfadtBUHePNtTGdtV0gN6rkUbclSOgE8VZ+D2BY65Vt10dtZZlsrouxEynz+rYdgjF09sVx2bJF4pSpk5T0ChelA8COg52iayCpgiVW010DKA+HsGVvOxzb5qZVmKJ3jusCgH/VWacxxsDkCD6ASakRDJh8SnOd8KSC0vq3SmsU04sgSOhEsbAPwxjCZCy3EcuE+ipdHglxz5ejclC268EQnH/68vMBxnzHtgsidW6a6OjpY1v3H1IVkXBJrUfnjMH1pXpp514AEIVor1x0rnDRaQvVGXOmG539iRG9TowBtuOxSU01iEVDdyQz9lbX81FML4I4EoOagBhjbgHw/qH8olIalmmo1voqrbQetYdRzhkO9Q1gybRJxmeuXOX9510PS8+XwhR8VCVrcA4X4C9s3y0vXDJPswLOQ58o5eEg9nR2qXXb9xTk8xhjcGwbleVR7/pLzhXprM2UUiP+4GW7HkIBE5euWPBsOutACIqBCBI6Qbwd9wHYBmDmsW+uPmpiUdlQVcGy9uhOZTIwHOodwDXnnSG27j+kHn1pMyQPFCJ1m72wdRc72NMvwwHLyDhu0V9ApTVi0QjufOZFnUxnhBkY3Sx9xhicXLvIL151CSbUVondnd0Qo7BVq0ZuVUVDdcWZQogfaBrmJkjoBPGO/ArAjcf6Jdfz0VAd09FwUCTS2VGWRi46S2Sy/KsfvJwd6ot7r+7Zb1iBwKgq3bAsdPb28+e37lTvWbEEqa7eoq8cFzRNDKTS6vENWxhGebkaYwye7wNaqY9fdK68aMlca19X36jIPPdglyNju6cAMEFJcUQRQ+NHRDFwzOxhDUAIrhtrKhiAglRe4ZyhP5WGwRn73ieuZm2NdZ7rOKM67J4Xk3jopVfgeL4yinyIV2mNulgZ1ry6Q27d186EOXrJcIwx+FJC+b66dNkp3qcvPdfo6ItDqYKsRJgEYB51VYKEThDvzEEco9CM5/moiIRkQ3U5nAImAwnOcXgggapo2Pivv72GT2qscz3HgdZ6VGa4tdZgwsD67bv52td2qfpYOYp5mNcUAq4v1b3Pb8g/c41SpMwYPM+H9Dx1zqI53tc+dLnZn8rwrOMVchXCUuqqBAmdII7Nz9/pD11foroiosvDIeYVOLtXcI4D3f2oLosaP/7/PsKntjR6nutCSTUqMrFyJVPF3c++rBljulgTsZTWaKyKYfXm19S6bTsFH6WCOINz5kr6+vLTl/jfvfYqM207PJ7OgBe2Hh1F6AQJnSCGwDMAnnq7P/R9iZpYmT7RnbSOF0NwtPf2oyIcMm7+3LXitFnTfN/zlOeNfISotQaEwFMbt/BnXtkhm6piOJ79vUeboGXC9jx565PPawDCHA2h57PZoZX/yUvP87/5V1eY8UyW96fSozZv/g4som5KkNAJYmj86u0EZ5qGrIlFobQas++s4Byd/XEwgP/npz8s3nv2Uqmk1I5tAyMs9UBuLlr8/KGntO16Khy0impdulQKzVUx3Pf8y3LT7n3cMK0RnRpgjEFrDde2EQ2H5Hc/8UH9t5e+y+zoi7Nk1h4LmQPAZAAB6qYECZ0gjs0fABw6mjzCQYtVloW568kxPUDBOXoSKQykM+xrH7jM/OqHrlBcGL5r21Baj1i0rrWGYVnYsu+guOPpdbKpOgZdJFG61hqV0QgO9g7IXz38NAMgRnJagDEG13Xhua6eMbHZ/eXfX4eVi2abuzu74XjeWGb91wGYSN2UIKETxLHJ4Cj13V1PIhYNeWXhkPakHPODFJwjbTvY392Hq886Tfz6i59gU5obfd91leeO3BB8Pgrl/3P/42zTnoN+U3UMUqkxP3/GGKrKIvqXD6/WXQNxwwoGRyQ6Z8itZnBsG1op9f5zl/u/vOE6o6m6Uuzu7H79s8eYCdRNCRI6QQyNX775B76UqIiEjWDAFFKq4ug4jEEqhZ0dXZjaWCd+ccPH+PvOXuYrJaVj29D6xOWjtUYgGITn+cZ3b78fnpSqPBwa06x3pTSaayrx1OZt8o9Pr2VgnGEkZM4YPCnhOY6urazwvnf9h9RXr77ETGayvKNvYKyG2I9GJXVRgoROEENjG4B73vzDqoqIJzgvqgorLC/29t5+OJ7Pv/HBy8zvX/8h3Vhb7Xmuox3XPeG5da01zEAAr+w5wH90z6OysaoChhAYC6drrVEWDiLjuOq/731cAxCBE9xEhrFctrxj21C+ry44baH/2y9dz8+dP9PY09mDtO0Uk8wBoIq6KEFCJ4ih8z9vEJohdGVZ2NQozl1FBedIZW3s7uxmZ8+bYdzyxU/yq85Z5kNr6do25AnWGOeMAULwPzz1gnHL48/5LTWVGmOUIlcfK8fPH1ottx/sMMxA4MRGCxiD63rwXVc31FT5N173AXnjte8zLEOIvYd7Xo/ciwxKiiOKFir9ShQjDwN4AcBSXypEggE/VhbWrueLYj1gxhg0gH1dvagIh8Q/Xn0pP3/RHPnf9z/hbdyxR0jP46ZlgXM+bAlqrREwTThSsu/efp+uLIvIM2ZPNXoSqYKdn1QKE2qrsWbLTu+3jz7NAcZ4PhP9eNrK931I3wcYl1eds1x94sKzRFVZhO/r6oVSqtii8iOpoe5JUIROEMPjZiC3MUZFNMzKwkHh+6roD1pwjmTWxu7OHjZvUotx82c+avzDh66QdVUxz3Nd7dgOjqfI3OB8OgDzyQ2vesGAJQsVu2qtUREJIWU78gd3PgQAIhAcfnTOGINSueF16fty4fTJ3s8+/zF87QOXmIyB7z3ck6uUV9y16+meSVCEThDD5HcAvun5sqW+qswIByzER3lDlpGM1gGgo28AAcNgV61YYp49d7q6ffU6//bVL7BMJisY58w0LQxn6HxQoDs6upGxXVUeCYn+5OhXS+Oco7aiXP/rbfep4x1q1wBc2wYA1VxXI6+74CxcdOo8Q2uw3Z05kRdxVH4kXdQ1CXraJIjhYQP4rdYaUukNjLN0yXWufOb2ns5ucM75Z69caf7qhuvYu886TRpC+K5ja8/zhpU4ZwYC2N3eGfzOrffqSCCgQwFzVLPepVJoranCo+tfkbf/+XkOLoZ8tIPL0FzHhec4OlZe5n/68pXyV39/nbh82UKzO55kh/oG3vAQVAK41DUJEjpBDBOtcYsQvCMSDDyglC7Z7yrnHCnbwa6OLtRURMU3P3SF8YsbrmMXLz3F54xL17YxVLFzxsANgz3y4ibz54+s9msrykdnl5j8iEB1WRQHevr8G29/IJfVbh17NzWW/7tOXuTRSEh+ZNVZ/m++8An2qYvPMaVUfO/hHvhSFf3WsEehj3omUazQkDtRzErfYgj+kdqqssVa61ApnwnLR6EDqQwGUhlMrKsW3/nr94j3nblE3vLEc/6TG15lrm1zxgUzLRNvty4tl/VvwPF99tMHnmRLprXJWa2NRnc8OeJRrhAchiH0j+55TPfGE4Z1jKH23By5guu6AKBCoZC6bOlCXHXmqXx6c73ZHU9i56EucM7Aeck+n/VSvyRI6ERBSGWdcXMujuuhPBJ6LBoKxDxfjotzGpRuTyKJnkQS05rqxPc+fpVet+NU+Yen1/lPvPwqd21bMM7xdnPsgwlyjm0btz/1gvuta96jDSHYSFeRi0Ui2Lh7v3zs5VcA9vYT9YP7lEvPAwBdXhaVVy4/RV962gI2rbne6E+lsfNQFxhnKLJSAsNFAthLdxmChE4UhAuWzhk355LLcA+hPBIayO17PX6u06DYu+NJcM7ZvEktxmnT2/S6HXvk7U+t8554+VXuOrYA5zBN820H1bfsO+T2p9LMFMIcaaGbhkAynWXQmgnTONpJwPd9KN8HAFlXXYkrl5+iLzl1PptYX230JdPY09kNoORFPkgXCZ0goRMFY+6UlnFzLoNJZamM7bDxZPM3iV1rjcP9cTDG2NyJLcYpH5+k1+cj9qc2bmWe43AADIzByO3CBt9xAECumDfDqoyGzd5RWJMeT2cwp62FTWtpkDsOdgqYJgwhoLSG53qAVgAgZ0xsUZctXYB3LZglGqpioi+Rwu6OboAxjLPrtiUfpRMECZ0YfRIlsrRrmNIb9/OWg+I73B8H45zNmdRs3Dh1ot68t12tfuU1+dKOfXr7wQ7uOI4CANMKsGtXrVAfOmepEc9kT7ga3dHI2C5qK8r4N695j/7Gb+/ydh3sYNLzDABKGKZcPnsGu/S0+Vg+a6ooCwX54YFELqO/gCLXg+ddmM/bRHcYgoROECdGLwB/1L+vWkNJCW6MXbdgjAFao6s/Ac4Ym9xQIxZObkUya6ud7Yf11oMdntIai6dOCsxoabAODySQddxRWcPNOUPXQAITaqvFzz53LXti41a/sz+BcMCScyY06QWTWw0ArDueRG8iBcZYwbLWORfIJuOA1gjHqiA9txBSf4a6IkFCJ4gTYwDAYQDNoylzYQXApK8TXR0sHKuCYQWgx2i70sFSsv2pDPqSaRhC8EmNtZjX1hIGGOKZLPZ39QKMjWpBFiE4uuIJBAyDX7xkvhUwDUilzGTWRkdvHErnIuSCDa3nP2egsx1VLRPV3Auu8LY+8aDpZNLcsKzR/GQbwDrqigQJnSBODAfAntEUutYadjKuT3v/tZ6XzYjnb/s510qxaE0tOBdjumUpy2/Vmkhn3zClUiiJDuYydPbHjz6iUKh24By+4yDZ3aGb5yzSKz/zNXVo6yb0t+/joYpR39X0OQAHqCsSxQwVliFKhYOjLQvpuWz32qeNqaefq977Lz+SrQtO9ZPdh3V6oLeQ87TE21yfzEAfMgO9avGVH/ZWfuZrWvkef/GPvzGFaYKxUb+V3U9XgSChE8TIMOoJSaGKSuzfuJb/+Wf/zkLlMX7OJz7PV33mH73K5olyoOMAnHSyEOIg3jQCoLXGQMdBBKPl6oLPfcOfd9F7DAD8pbtvVf3tB3iwrAIF2E72broaRLFDQ+4ECT2PVgoVDS3Yu+5ZY21FpTztqmtZw4x51kUz5vk7n33S3/TgnXzg0H4eqa6BGQyP2fz6yRSVO+kkMv19auryc9TSD3ycmcGQCYC1v/qyt/2ZR0VZbV0hrsN9AHbTFSFI6AQxMmwAkAEQHu0PqmhoxtbHHxSRqlpnznmXGgCMqaefqyeeskxtffJP3ranHhHxjgM8Ul0Pw7JI7KMUlScOH4IVjqqzP/F52bbkDA5AAICdTPhr7/g158LgwixI+/+ErgpBQieIkaMdwFYAi0c3TNfgQiBaXYv1d/3ODFdU+W1LTucAmBkMifkXvZdNXX6u2vzIPWr3C6t5ui/Lo9W1EIYFrUnsIxKVp1LIxPswcdFSf+nVH9PhWJWBv+xAo56/9WaW7OoUFY3NhZD5WgAP0JUhSOgEMbL8edSFjlzGuxEMIiDL+Zrf/Ng0AgHVOm+xyP8xD8eq+NL3X6tmnn2BevWRe9Te9c8L33VZtLqGxH4CUblSConOdgQiUXXmtX8npyw9i7/pHqU2P3S33Lv+eTPW2FKokZH/oqtDlAqU4UOUEg8X6oO0UghEojADIfbML/+Ld+7Y8uaSn7yivsk4/ZpP84u/+C/+1OVn+3YqqeKH2yF9D4xT1xpOVJ5NDCDR1aHblpwuL/vqv6kpS88ykB9iH7wkB1992d/4p/8zojV1hVoutwHALXSFCBI6QYw8TwPYX0ipB8srwIRgT/7v91jXrm1Hq+PNY02t5ul/9Sl+0Rf+WU1fcb7n27YaOHQAvmOD0VK3dxS57zoYaN+PUEWVfNenv+Sfee1n2JuG2AEAyZ7D8rlbfsINK8DMQLBQdQG+TleJIKETxOhgA7inkB+olUKoPAYGxh//8XdZx7bNEkdfI8UrmyYYyz54nbj4y9+Rc1Ze5oEx1X/oANxMmtawHylyxqCVQryjHV42oxdd8UHvsq/eqFvnLTaOdk9ysxn/zz/9d+6kU0aoorJQQ+33g9aeE6XWt8ayAhYx8tz9rc+P91M8A2NQU5txDjsZh+84+syPfVZNWLCEHeOBWGXj/WrXC6v17nXPsIH2/cIIhFioIgbOOU7Gfjco8lRfD8Cg2hafruZf9B5WVtvwTm3pPfbjf8WhLRvNiobmQslcApgD4LVib9Mr/+k/6KZHvA4lxRGlxpq80FcUOlIPllXAYUn21M038eUfvt6duvycN8/zviFiD1VU8rmrrlCzzr1Y7l3/nL/7hdX88M6tXCnFwhWVMAJB4CQQO2MMSiqkBnqgpK9b5iyS8y68Ute2Tefv0H4AIJ/+1Y/QvvllM9bUUsjlgV8sBZkTBAmdGA/8pNBCH5R6IFoGxgVb89v/MVN93WrhJVdpvGm+981iF6bJpyw9C1OWniW7dm3zd699BgdfWS/ine3cCoYRLCsHF2LcRe2MMSjfR2qgD4BWjdPnqlnnXYKmWfM5jj3dJ5+/9WfY9dyfcxnthTvshwFQ2EuQ0AmiQNwC4PMAThkLqVuhEIRRxzfc9wee7O7yzvjIpzTnYihbfYm6KTNF3ZSZKhPvl/s3rJUHNq5jPXt3cs+xeSBSBiscyWXIl7DcGWNw7Syy8X6YgaBumbdYzTx7lWqYPocN8Z6jXrjt59j21MOiorEFKFx7DAD4OHUvgoROEIXlRgB/GIsP1lpDmCZijc3Y9cKfzcThdv/s6z7vRatrjWNE669H7eGKSj7z7Av0zLMvUL37d8v9G9b6h7Zu4v3t+4X0PRaMlsMKhUtn+RtjUL4HO5WEl80gWlMnZ55zoZ52+rmobJ7IAZhDfCf/ud/fjNeeetioaGwu9MPNR5ArYEQQpfkwTUlx44uTICnuSB4DcN6YdiDOkew+DDMUkss/9Ek5YcGpAu88L/y2UalSUnbv2o72Vzewzh2v8nhnO/PsLMxAkFnhKIRpASie/soYg/R9OKkkXDujg5EyXTNpqm6dv0RNWHgaC5aVD2Vo/Ui81T//IXavfdqsaGwptMy/DuBfSq0DUFIcQUInoY8XFgFYP+adiAvYyTjsZFzPPu9Sb/G7Pyy4EOIE3lIpKXXPvl368I6tsnv3NtHfvp9nEwNcKw3DCsAMhSEMo+ARvFISvuPAzaShpEQgGlXVrW2yYfoc3TJ3EY81TRjMWB/WOj0nnfL//NOb0Llji1HR0Jx/binYvel2AB8oxQ5AQieOhIbciVLmZQD/CuAfxvIgtJIIRsthBoPs1cfvszq3vypPv+ZTXnVrm8Dx1XrgXAjUTZ6OusnTOXCFTvf36t59u7zefbt074G9PNHVwbOJAe07thCmCW5YMEwThhXIzTnnI+jjOp/Bh3yl4LkOpOdCui6k9BEIR1S0pl41z16AmklTWcOMuaqivonlRyWO51x1/6H93p9/cpOR7O3isYbmQicHvlCqMicIitApQh+PrAFwehF0JzDOkO7rgVZKz1l5uT//wnczbhgj+eCsACAT75MDhw6yRGe7HuhsZ6m+bmYn4jIz0GdJ31NKSqZ8nwEaTAhwzsGYAD9y4IAxKOlDKwWtJJSUABi4MDQXQgvL4uGKSjdUERMV9c2qvL6JxZpaUdU6CYZpDUr8RJB71j2jn7/1Z1xr8EhVdaF3rtsNYCmAnlL94lOETlCETow3PgpgIwqwteoxgk1opRGpqoHv2Gzj/X8w929cK0997zVe48z5x1pzPeToHQDCFVU8XFGFplnzFXLD29JJp5Du64GTTmYzA31Gur834NlZ3/dcx7ez8F3XcDKpwGDkrpVCIBxxDSvgikCQmYGgaQQCVjhW5UWrav1ApCwcra7VVjiij7hXjEjJOyWlv+6Pv8bWJx8UkYoqZkWihZZ5L4BzSlnmBEFCJ8YjOwFcDeC+YjgYrRSEGUCsqRXp3h7x6H/+Pz7p1NP9RZddrcpq6o93aPodBQ/ACESiCESiABB5w7DBX/r50R4oBP6SgT74Xlb+BQCBEW4e1bN3p3zu9z/lfQf2ivK6RghhFFrmSQDvAnCAug5BQieI4uN+AH+HotnuUkNrIByrhFLlbN9Lz5uHtmxUM85cqWa/62IViA47A/x4OVbW/fFm5Q+7QaTnyk0P3olXH7vP4IbJYk2tueH+wk77ZQCcCWATdRmChE4QxcuPAFQC+OdiOSCtNRjjKK9vhO/YfNOf/sh3r31aTT9zpZxx5kplhSOFEvtYog5uekm+dM/veX/7AVFWWwfDChQ6Kgdyw+tnANhOXYUgoRNE8fNt5IaLv1ZMB5UbhrcQa54AN5PiL931O75jzeNq6vJz5bQzzlOh8orxKHbZs3en2vTgH9nBzetNKxxBZXM+Ki+8zHcBOBtUOIYgoRNESfH1fDT2g2I7MK0UzGAYlc1RuJk0f/ne2/j2Zx5TExctlVOXnS0rWyYNir2U91uVPXt3qi1PPMAObHzRAMDK65te321tDFgD4AIAaeoaBAmdIEqPHwLYD+DOYjy4nNhDiDW2wHNsvvWJB/mONU+oplnz1aTFp/st8xczw7RKKWrXAOShLRv19jWPo/2Vlw2lJItW1YALA1rrsdp85jfIrYIgCBI6QZQwdyG3r/WDACYUpQV1rvJbRUMTpO/z9i0b+IFNL+ry+ibVPGeRbJ2/WNVOng7ORTHKXQNQqd4uve/ltXr/hrW8d/8uwRhj4VjVWIscyCVJ/oi6AUFCJ4jxwRYAU5Hboe39RRveag0uBCJVtWAazE2nxdYnHhDbn35Ex5omqMYZc1XjrPmytm0aE4Y5lnLXAGS6rxvtWzbh0LZN6N69nWUG+oxAOIpodS0Y42Mt8h4AFwNYR19/goROEOMLD7l16n8A8CsA0aI9Uq2hAZihEMxQCFprluzuFD17d2DLEw/o8vomWTNhsq5pm+ZVT5iCWGMz48LgedGO9PIzjXxlOiedUn0H97KevTt1167XWN+BvTwb7+PCCiAYLUOu/rp+/eFkDPkjgL8CYNPXniChE8T45Y8AHgbwvwA+XAoHzBhDIFKGQLQcWilmxweMXS+sxs7nnxKBcFRFa+p0eW2DqmhsUZGqGlZR12QHysrDwWi5b1iWCyB4RDT/5ow0hr8k30kArmdnA04qifRAn5M4fCiQ6u32BzoOGImuDpbu7zWk60CYAQSiUZTXN73hQWSMsZHby/z39DUnSOgEcXKQykdwP8iLfXFJHLXWYIzBDIVhhnIVbpWUPNXThYFDB+CvfRrcMLUVCltmMIhQeUyHyis1N01YoRAMK4BApMzhQkitNWOcK+m6ppNJBX3HgWfb2ndslYn3aSeVEJ5tm242zQEEjEAQRiCIcHkMYEWZfH8ngGsBJOjrTZDQCeLk40UASwBcCOAmALNL7QS4ELDCEVjhSN75mmmlDCUl4oc7zL6D+8zcMjE9uBtp6K1DAIMhOjO4EIawLAjTghkKG1Y0Clbcq+d2AfgEgCfp60wQJHSCeCj/uhjAPwE4rVRPhDEGJgQgBIRpjedrlgLwFQA/pq8vQRzxkE9NQBAAgD8ht5XmYgC/A+BTkxQdCsC/AKghmRMECZ0gjsV65ObYawB8CsDz1CRjThLAtwBUIVcF0KEmIQgSOkEMlTiAnwBYDmA6gH8guRecPQA+A6ABwDfz14QgCBI6QRw3OwDcmJd7C4DrANwGoJOaZlT4E4CVACYjtx1uhpqEII4NJcURxPBoB/Dz/IsjN+e+HLltOU8F0EZNdFxsQK6a3+8BdFBzEAQJnSAKiUKuvOg6AP+Z/9kU5JbDnQJgLoB5AFqpqY7KOgB3A7gDuVEQgiBI6ARRNOzKv24/4mdtAGYBmIHcZjHTAExEbvhenERtsw3AMwCeBvA4aG9ygiChE0SJsSf/+tMRPxMAGvPR+6T8vxsBNOdfNchldZcDKLVF5X3IbV27HcAr+ddL+Z8RBEFCJ4hxhQRwMP967m1+J5oXewxARV7w1fn/L8//rCz/34H8v00AkfyrDEDdCBxrHLkEwACAfuQKuyTyP+/J/1lH/lw6AOzL/w5BECR0giDyUhyKGCvysi3LCz2c//8q5Crf8fwDxHBhAEIANgHYmn/AGACQRm5teC+oAA9BFA1Mj/0uSQRBEARBnCC0Dp0gCIIgSOgEQRAEQZDQCYIgCIIgoRMEQRAEQUInCIIgCBI6QRAEQRAkdIIgCIIgSOgEQRAEQZDQCYIgCGKc8f8PAK+c7H+xA4I0AAAAAElFTkSuQmCC
+      mediatype: image/png
+  labels:
+    alm-owner-openebs: openebsoperator
+    operated-by: openebsoperator
+  selector:
+    matchLabels:
+      alm-owner-openebs: openebsoperator
+      operated-by: openebsoperator
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: openebs-operator
+          rules:
+            - apiGroups:
+              - "*"
+              resources:
+              - clusterroles
+              - clusterrolebindings
+              verbs:
+              - "*"
+            - apiGroups:
+              - "*"
+              resources:
+              - namespaces
+              - services
+              - serviceaccounts
+              - pods
+              - deployments
+              - daemonsets
+              - secrets
+              - events
+              - endpoints
+              - configmaps
+              - jobs
+              verbs:
+              - create
+              - get
+              - list
+              - watch
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - apiextensions.k8s.io
+              resources:
+              - customresourcedefinitions
+              verbs:
+              - create
+              - get
+              - list
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - admissionregistration.k8s.io
+              resources:
+              - validatingwebhookconfigurations
+              verbs:
+              - create
+              - get
+              - list
+              - watch
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - openebs.io
+              resources:
+              - openebsinstalltemplates
+              - openebsinstalltemplates/finalizers
+              - openebsinstalltemplates/status
+              verbs:
+              - create
+              - get
+              - list
+              - watch
+              - patch
+              - update
+              - delete
+      deployments:
+        - name: openebs-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: openebs-operator
+            strategy:
+              type: RollingUpdate
+            template:
+              metadata:
+                labels:
+                  name: openebs-operator
+                name: openebs-operator
+              spec:
+                containers:
+                - name: openebs-operator
+                  image: index.docker.io/openebs/helm-operator:v0.0.5
+                  imagePullPolicy: Always
+                  env:
+                  - name: WATCH_NAMESPACE
+                    value: ""
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: "openebs-operator"
+                serviceAccountName: openebs-operator
+  customresourcedefinitions:
+    owned:
+      - name: openebsinstalltemplates.openebs.io
+        version: v1alpha1
+        kind: OpenEBSInstallTemplate
+        displayName: OpenEBS Install Template
+        description: Represents a OpenEBS Install Operator
+        resources:
+          - kind: ServiceAccount
+            name: ''
+            version: v1
+          - kind: ClusterRole
+            name: ''
+            version: rbac.authorization.k8s.io/v1beta1
+          - kind: ClusterRoleBinding
+            name: ''
+            version: rbac.authorization.k8s.io/v1beta1
+          - kind: Deployment
+            name: ''
+            version: apps/v1beta1
+          - kind: Service
+            name: ''
+            version: v1
+          - kind: ConfigMap
+            name: ''
+            version: v1
+          - kind: DaemonSet
+            name: ''
+            version: extensions/v1beta1
+          - kind: Secret
+            name: ''
+            version: v1
+          - kind: ValidatingWebhookConfiguration
+            name: ''
+            version: admissionregistration.k8s.io/v1beta1
+        specDescriptors:
+          - description: Image pull policy
+            displayName: Image
+            path: image
+          - description: RBAC creation policy
+            displayName: RBAC
+            path: rbac
+          - description: ServiceAccount creation policy
+            displayName: ServiceAccount
+            path: serviceAccount
+          - description: OpenEBS release version
+            displayName: Release
+            path: release
+          - description: Maya ApiServer Attributes
+            displayName: MayaAPIServer
+            path: apiserver
+          - description: OpenEBS Provisioner Attributes
+            displayName: Provisioner
+            path: provisioner
+          - description: LocalPV Provisioner Attributes
+            displayName: LocalProvisioner
+            path: localprovisioner
+          - description: OpenEBS Snapshot Operator Attributes
+            displayName: SnapshotOperator
+            path: snapshotOperator
+          - description: Node Device Manager Attributes
+            displayName:  NodeDeviceManager
+            path: ndm
+          - description: NDM Operator Attributes
+            displayName: NDMOperator
+            path: ndmOperator
+          - description: Validating AdmissionServer Webhook Attributes
+            displayName: WebHook
+            path: webhook
+          - description: Jiva Data Engine Attributes
+            displayName: Jiva
+            path: jiva
+          - description: cStor Data Engine Attributes
+            displayName: cStor
+            path: cstor
+          - description: Monitoring Policies
+            displayName: Policies
+            path: policies
+          - description: Google Analytics Attributes
+            displayName: Analytics
+            path: analytics
+          - description: Enable Default Storage Class Installation
+            displayName: defaultStorageConfig
+            path: defaultStorageConfig
+        statusDescriptors:
+          - description: ClusterServiceVersion Condition
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+


### PR DESCRIPTION
Signed-off-by: Aamir Shaikh <aameer.shaikh@mayadata.io>
tested deployment on Openshift 4.6 OpenEBS was successfully deployed
```
root@aamir-inspiron-3593:/home/aamir/projects/helm-operator/olm# oc version
Client Version: 4.7.13
Server Version: 4.6.41
Kubernetes Version: v1.19.0+4c3480d
root@aamir-inspiron-3593:/home/aamir/projects/helm-operator/olm# 

root@aamir-inspiron-3593:/home/aamir# oc get pods
NAME                                                READY   STATUS    RESTARTS   AGE
oebs-openebs-admission-server-548794cff5-5gs95      1/1     Running   0          7m15s
oebs-openebs-apiserver-5d6648497c-4thsl             1/1     Running   0          7m15s
oebs-openebs-localpv-provisioner-7cc7464556-gz4cn   1/1     Running   0          7m15s
oebs-openebs-ndm-operator-7cdd54584f-xb7s6          1/1     Running   0          7m15s
oebs-openebs-provisioner-8dbbdcc5f-v5786            1/1     Running   0          7m15s
oebs-openebs-snapshot-operator-559498b555-mngtw     2/2     Running   0          7m15s
openebs-helm-operator-798f58bfb-p4wsb               1/1     Running   0          7h32m
root@aamir-inspiron-3593:/home/aamir# oc get sc
NAME                        PROVISIONER                                                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
gp2 (default)               kubernetes.io/aws-ebs                                      Delete          WaitForFirstConsumer   true                   4d16h
gp2-csi                     ebs.csi.aws.com                                            Delete          WaitForFirstConsumer   true                   4d16h
openebs-device              openebs.io/local                                           Delete          WaitForFirstConsumer   false                  4d6h
openebs-hostpath            openebs.io/local                                           Delete          WaitForFirstConsumer   false                  4d6h
openebs-jiva-default        openebs.io/provisioner-iscsi                               Delete          Immediate              false                  4d6h
openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   Delete          Immediate              false                  4d6h

```